### PR TITLE
only hiding the right TOC if it overlaps with sidebar content

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -10,6 +10,12 @@ typical `{sidebar}` directives, as well as a theme-specific `{margin}` directive
 This section covers both. Both allow you to place extra content
 separately from your main content.
 
+```{tip}
+Sidebar content will generally overlap with the white space where your site's
+table of contents lives. When the reader scrolls sidebar content into view, the
+right TOC should hide itself automatically.
+```
+
 ### Margins
 
 You can specify content that should exist in the right margin. This will behave

--- a/sphinx_book_theme/static/sphinx-book-theme.js
+++ b/sphinx_book_theme/static/sphinx-book-theme.js
@@ -58,14 +58,27 @@ var initTooltips = () => {
 var initTocHide = () => {
   // Hide the TOC when we scroll down
   var scrollTimeout;
-  var throttle = 100;  // in milliseconds
-  var hideTocAfter = 50;  // in pixels
+  var throttle = 200;  // in milliseconds
+  var tocHeight = $("#bd-toc-nav").outerHeight(true) + $(".bd-toc").outerHeight(true);
+  var hideTocAfter = tocHeight + 200;  // Height of TOC + some extra padding
   var checkTocScroll = function () {
-      if (window.pageYOffset > hideTocAfter) {
-        $("div.bd-toc").removeClass("show")
-      } else {
-        $("div.bd-toc").addClass("show")
-      };
+      var margin_content = $(".margin, .tag_margin, .full-width, .full_width, .tag_full-width, .tag_full_width, .sidebar, .tag_sidebar, .popout, .tag_popout");
+      margin_content.each((index, item) => {
+        // Defining the boundaries that we care about for checking TOC hiding
+        var topOffset = $(item).offset().top - $(window).scrollTop();
+        var bottomOffset = topOffset + $(item).outerHeight(true);
+
+        // Check whether we should hide the TOC (if it overlaps with a margin content)
+        var topOverlaps = ((topOffset >= 0) && (topOffset < hideTocAfter));
+        var bottomOverlaps = ((bottomOffset >= 0) && (bottomOffset < hideTocAfter));
+        var removeToc = (topOverlaps || bottomOverlaps);
+        if (removeToc && window.pageYOffset > 20) {
+          $("div.bd-toc").removeClass("show")
+          return false
+        } else {
+          $("div.bd-toc").addClass("show")
+        };
+      })
   };
 
   $(window).on('scroll', function () {


### PR DESCRIPTION
This now calculates the height of the TOC, and hides it only if an element with a class that is associated with "right margin" space overlaps with the sidebar.