### PR TITLE
adding source repo buttons

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -9,28 +9,59 @@ to use MyST markdown with your Sphinx website,
 see [the MyST-parser documentation](https://myst-parser.readthedocs.io/)
 ```
 
-## Add an Edit this Page button
+## Source repository buttons
 
-You can add a button to each page that will allow users to edit the page text
-directly and submit a pull request to update the documentation. To include this
-button in the right sidebar of each page, add the following configuration to
-your `conf.py` file:
-
-```python
-html_theme_options = {
-    ...
-    "use_edit_page_button": True
-    ...
-}
-```
-
-and configure your documentations repository information:
+There are a collection of buttons that you can use to link back to your source
+repository. This lets users browse the repository, or take actions like suggest
+an edit or open an issue. In each case, they require the following configuration
+to exist:
 
 ```python
 html_theme_options = {
     ...
     "repository_url": "https://github.com/{your-docs-url}",
-    "path_to_docs": "{path-relative-to-site-root},
+    ...
+}
+```
+
+### Add a link to your repository
+
+To add a link to your repository, add the following configuration:
+
+```python
+html_theme_options = {
+    ...
+    "repository_url": "https://github.com/{your-docs-url}",
+    "use_repository_button": True,
+    ...
+}
+```
+
+### Add a button to open issues
+
+To add a button to open an issue about the current page, use the following
+configuration:
+
+```python
+html_theme_options = {
+    ...
+    "repository_url": "https://github.com/{your-docs-url}",
+    "use_issues_button": True,
+    ...
+}
+```
+
+### Add a button to suggest edits
+
+You can add a button to each page that will allow users to edit the page text
+directly and submit a pull request to update the documentation. To include this
+button, use the following configuration:
+
+```python
+html_theme_options = {
+    ...
+    "repository_url": "https://github.com/{your-docs-url}",
+    "use_edit_page_button": True,
     ...
 }
 ```
@@ -42,6 +73,17 @@ to change this, use the following configuration:
 html_theme_options = {
     ...
     "repository_branch": "{your-branch}",
+    ...
+}
+```
+
+By default, the edit button will point to the root of the repository. If your
+documentation is hosted in a sub-folder, use the following configuration:
+
+```python
+html_theme_options = {
+    ...
+    "path_to_docs": "{path-relative-to-site-root}",
     ...
 }
 ```

--- a/sphinx_book_theme/static/sphinx-book-theme.scss
+++ b/sphinx_book_theme/static/sphinx-book-theme.scss
@@ -366,10 +366,15 @@ div.highlight {
             margin: 0 .1em;
             background-color: white;
             color: $non-content-grey;
-            font-size: 1.4em;
             border: none;
             padding-top: .1rem;
             padding-bottom: .1rem;
+            font-size: 1.4em;
+
+            i.fab {
+                vertical-align: baseline;
+                line-height: 1;
+            }
         }
 
         // buttons float right
@@ -400,9 +405,15 @@ div.dropdown-buttons-trigger {
     div.dropdown-buttons {
         display: none;
         position: absolute;
-        max-width: 120px;
+        max-width: 130px;
         margin-top: .2em;
         z-index: 1000;
+
+        &.sourcebuttons .topbarbtn i {
+            padding-right: 6px;
+            margin-left: -5px;
+            font-size: .9em !important;
+        }
 
         button.topbarbtn {
             padding-top: .35rem;

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -16,3 +16,5 @@ expand_sections = []
 navbar_footer_text =
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
+use_issues_button = False
+use_repository_button = False

--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -24,8 +24,17 @@
             {% endif %}
         </div>
 
-        <!-- Edit this page -->
-        {% if theme_use_edit_page_button and github_repo %}<a class="edit-button" href="{{ get_edit_url() }}"><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip" data-placement="bottom" title="Edit this page"><i class="fas fa-pencil-alt"></i></button></a>{% endif %}
+        <!-- Source interaction buttons -->
+        {% if theme_repository_url and (theme_use_repository_button or theme_use_issues_button or theme_use_edit_page_button) %}
+        <div class="dropdown-buttons-trigger">
+            <button id="dropdown-buttons-trigger" class="btn btn-secondary topbarbtn" aria-label="Connect with source repository"><i class="fab fa-github"></i></button>
+            <div class="dropdown-buttons sourcebuttons">
+                {% if theme_use_repository_button %}<a class="repository-button" href="{{ theme_repository_url }}"><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip" data-placement="left" title="Source repository"><i class="fab fa-github"></i>repository</button></a>{% endif %}
+                {% if theme_use_issues_button %}<a class="issues-button" href="{{ theme_repository_url }}/issues/new?title=Issue%20on%20page%20%2F{{ pagename }}.html&body=Your%20issue%20content%20here."><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip" data-placement="left" title="Open an issue"><i class="fas fa-lightbulb"></i>open issue</button></a>{% endif %}
+                {% if theme_use_edit_page_button %}<a class="edit-button" href="{{ get_edit_url() }}"><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip" data-placement="left" title="Edit this page"><i class="fas fa-pencil-alt"></i>suggest edit</button></a>{% endif %}
+            </div>
+        </div>
+        {% endif %}
 
         <!-- Full screen (wrap in <a> to have style consistency -->
         <a class="full-screen-button"><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip" data-placement="bottom" onclick="toggleFullScreen()" title="Fullscreen mode"><i class="fas fa-expand"></i></button></a>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,7 +8,7 @@ path_tests = Path(__file__).parent.resolve()
 path_base = path_tests.joinpath("sites", "base")
 
 
-def test_build_book(tmpdir):
+def test_build_book(tmpdir, file_regression):
     """Test building the book template and a few test configs."""
     # Copy over the base build content and config to tmpdir
     path_tmpdir = Path(tmpdir)
@@ -113,14 +113,19 @@ def test_build_book(tmpdir):
     )
     rmtree(path_build)
 
-    # Test edit button
-    cmd = cmd_base + ["-D", "html_theme_options.use_edit_page_button=True"]
+    # Test source buttons edit button
+    cmd = cmd_base + [
+        "-D",
+        "html_theme_options.use_edit_page_button=True",
+        "-D",
+        "html_theme_options.use_repository_button=True",
+        "-D",
+        "html_theme_options.use_issues_button=True",
+    ]
     run(cmd, cwd=path_tmp_base, check=True)
-    ntbk_text = path_ntbk.read_text()
-    assert (
-        '<a class="edit-button" href="https://github.com/executablebooks/sphinx-book-theme/edit/master/TESTPATH/section1/ntbk.ipynb">'  # noqa E501
-        in ntbk_text
-    )
+    ntbk_text = BeautifulSoup(path_ntbk.read_text(), "html.parser")
+    source_btns = ntbk_text.find_all("div", attrs={"class": "sourcebuttons"})[0]
+    file_regression.check(source_btns.prettify(), extension=".html")
     rmtree(path_build)
 
     # Test extra navbar

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -1,0 +1,23 @@
+<div class="dropdown-buttons sourcebuttons">
+ <a class="repository-button" href="https://github.com/executablebooks/sphinx-book-theme">
+  <button class="btn btn-secondary topbarbtn" data-placement="left" data-toggle="tooltip" title="Source repository" type="button">
+   <i class="fab fa-github">
+   </i>
+   repository
+  </button>
+ </a>
+ <a class="issues-button" href="https://github.com/executablebooks/sphinx-book-theme/issues/new?title=Issue%20on%20page%20%2Fsection1/ntbk.html&amp;body=Your%20issue%20content%20here.">
+  <button class="btn btn-secondary topbarbtn" data-placement="left" data-toggle="tooltip" title="Open an issue" type="button">
+   <i class="fas fa-lightbulb">
+   </i>
+   open issue
+  </button>
+ </a>
+ <a class="edit-button" href="https://github.com/executablebooks/sphinx-book-theme/edit/master/TESTPATH/section1/ntbk.ipynb">
+  <button class="btn btn-secondary topbarbtn" data-placement="left" data-toggle="tooltip" title="Edit this page" type="button">
+   <i class="fas fa-pencil-alt">
+   </i>
+   suggest edit
+  </button>
+ </a>
+</div>


### PR DESCRIPTION
this changes the "edit this page" button to instead be a "source dropdown" that allows for a few different actions. Meant to address @akhmerov's idea to have a feature like this in Jupyter Book!