### PR TITLE
fixing page title bug

### DIFF
--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -168,6 +168,11 @@ def add_to_context(app, pagename, templatename, context, doctree):
 
     context["nav_to_html_list"] = nav_to_html_list
 
+    # Update the page title because HTML makes it into the page title occasionally
+    if pagename in app.env.titles:
+        title = app.env.titles[pagename]
+        context["pagetitle"] = title.astext()
+
     # Add a shortened page text to the context using the sections text
     if doctree:
         description = ""

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -14,7 +14,7 @@
 <!-- Opengraph tags -->
 <meta property="og:url"         content="{{ pageurl }}" />
 <meta property="og:type"        content="article" />
-<meta property="og:title"       content="{% if title %}{{ title }}{% else %}{{ docstitle }}{% endif %}" />
+<meta property="og:title"       content="{% if pagetitle %}{{ pagetitle }}{% else %}{{ docstitle }}{% endif %}" />
 <meta property="og:description" content="{{ page_description }}" />
 {% if logourl %}<meta property="og:image"       content="{{ logourl }}" />{% endif %}
 

--- a/tests/sites/base/index.md
+++ b/tests/sites/base/index.md
@@ -1,4 +1,4 @@
-# Index
+# Index `with code` in title
 
 ```{toctree}
 :caption: My caption

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -63,7 +63,7 @@ def test_build_book(file_regression, sphinx_build):
     index_html = BeautifulSoup(index_text, "html.parser")
     sidebar = index_html.find_all(attrs={"class": "bd-sidebar"})[0]
     # Index should *not* be in navbar
-    assert "Index</a>" not in index_text
+    assert "Index with code in title</a>" not in index_text
     # Captions make it into navbar
     assert '<p class="margin-caption">My caption</p>' in index_text
     # Opengraph should not be in the HTML because we have no baseurl specified
@@ -75,6 +75,8 @@ def test_build_book(file_regression, sphinx_build):
     assert '<a class="edit-button"' not in index_text
     # Sub-sections shouldn't be in the TOC because we haven't expanded it yet
     assert "Section 1 page1</a>" not in str(sidebar)
+    # Title should be just text, no HTML
+    assert "Index with code in title" in index_text
     sphinx_build.clean()
 
 
@@ -96,7 +98,7 @@ def test_navbar_options(file_regression, sphinx_build):
     sphinx_build.build(cmd)
     ntbk_text = BeautifulSoup(sphinx_build.path_pg_ntbk.read_text(), "html.parser")
     navbar = ntbk_text.find("nav", id="bd-docs-nav")
-    assert "Index</a>" in str(navbar)
+    assert "Index with code in title</a>" in str(navbar)
     sphinx_build.clean()
 
     # "single_page": True


### PR DESCRIPTION
closes https://github.com/executablebooks/jupyter-book/issues/727 by using the docutils title instead of the html context title