### PR TITLE
reworking sidebar logic for new PDT code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,6 @@ html_theme_options = {
     # For testing
     # "home_page_in_toc": True,
     # "single_page": True
-    # "number_toc_sections": True,
     # "extra_footer": "<a href='https://google.com'>Test</a>",
     # "extra_navbar": "<a href='https://google.com'>Test</a>",
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ theme. See the pages to the left for information about what you can configure wi
 ```{toctree}
 :maxdepth: 1
 :caption: Main docs
+
 configure
 Controlling page elements <layout>
 notebooks
@@ -55,6 +56,7 @@ GitHub repository <https://github.com/executablebooks/sphinx-book-theme>
 ```{toctree}
 :caption: Reference items
 :maxdepth: 2
+
 reference/index
 ```
 

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -25,9 +25,7 @@ folder as your content, then Binder/JupyterHub links will point to the ipynb
 file instead of the text file.
 ```
 
-## Types of Launch Buttons
-
-### Binder / BinderHub
+## Binder / BinderHub
 
 To add Binder links your page, add the following configuration:
 
@@ -41,7 +39,7 @@ html_theme_options = {
 }
 ```
 
-### JupyterHub
+## JupyterHub
 
 To add JupyterHub links to your page, add the following configuration:
 
@@ -55,7 +53,7 @@ html_theme_options = {
 }
 ```
 
-### Google Colab
+## Google Colab
 
 To add Google Colab links to your page, add the following configuration:
 
@@ -69,9 +67,9 @@ html_theme_options = {
 }
 ```
 
-### Live code cells with Thebelab
+## Live code cells with Thebelab
 
-[Thebelab])http://thebelab.readthedocs.org/) converts your static code blocks into
+[Thebelab](http://thebelab.readthedocs.org/) converts your static code blocks into
 *interactive* code blocks powered by a Jupyter kernel. It does this by asking for a BinderHub kernel
 *under the hood* and converts all of your
 code cells into *interactive* code cells. This allows users to run the code on

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -260,21 +260,6 @@ html_theme_options = {
 }
 ```
 
-### Numbering your TOC sections
-
-If you'd like to number your Table of Contents sections, use the following
-configuration in `conf.py`:
-
-```python
-html_theme_options = {
-    ...
-    "number_toc_sections": True
-    ...
-}
-```
-
-Note: external links will be skipped in numbering.
-
 ## Add metadata open graph tags to your site
 
 OpenGraph tags can be used to generate previews and descriptions of your

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "setuptools",
         "libsass",
         "pydata-sphinx-theme~=0.3.0",
+        "beautifulsoup4",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/sphinx_book_theme/sidebar.html
+++ b/sphinx_book_theme/sidebar.html
@@ -15,8 +15,7 @@
 </form>
 
 <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  {% set nav = get_nav_object(maxdepth=3, collapse=False) %}
-  {{ nav_to_html_list(nav, include_item_names=True, with_home_page=theme_home_page_in_toc, number_sections=theme_number_toc_sections) }}
+  {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc) }}
 </nav>
 
 {% if theme_navbar_footer_text %}{% set theme_extra_navbar=theme_navbar_footer_text %}{% endif %} <!-- To handle the deprecated key -->

--- a/sphinx_book_theme/static/sphinx-book-theme.scss
+++ b/sphinx_book_theme/static/sphinx-book-theme.scss
@@ -637,11 +637,8 @@ button.topbarbtn img {
     }
 
     // Captions
-    li + li.navbar-special {
+    p.caption {
         margin-top: 1em;
-    }
-
-    p.margin-caption {
         margin-bottom: 0;
         font-size: 1.2em;
     }
@@ -717,26 +714,45 @@ nav.bd-links {
     margin-left: 0px;
     max-height: none !important;
 
-    ul.nav li {
+    p.caption {
+        font-size: 1.4em;
+
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+
+    ul {
+        list-style: none;
+    }
+
+    li {
         width: 100%;
     }
 
-    ul.sidenav_l1 > li {
+    li.toctree-l1 {
         font-size: 1.2em
     }
 
-    ul.sidenav_l2  {
+    li.toctree-l2, li.toctree-l3, li.toctree-l4, li.toctree-l5  {
         font-size: .8em
     }
 
-    ul.nav > li > a {
-        padding-left: 0rem !important;
-        padding-right: 0rem !important;
-    }
+    > ul.nav {
+        // Make sure the first items don't have any padding
+        padding-left: 0px !important;
 
-    ul.nav ul {
-        padding-left: 1rem !important;
-        padding-right: 0rem !important;
+        // Subsequent items should have padding
+        ul {
+            padding-left: 1rem !important;
+            padding-right: 0rem !important;
+        }
+
+        // Links don't have the padding, uls do
+        a {
+            padding-left: 0rem !important;
+            padding-right: 0rem !important;
+        }
     }
 }
 

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -11,7 +11,6 @@ repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
-number_toc_sections = False
 expand_sections = []
 navbar_footer_text =
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>

--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -22,7 +22,16 @@
 
         {% include "topbar/launchbuttons.html" %}
     </div>
+
+    <!-- Table of contents -->
     <div class="d-none d-md-block col-md-2 bd-toc show">
-        {%- include "docs-toc.html" %}
+        {%- if toc %}
+        <div class="tocsection onthispage pt-5 pb-3">
+            <i class="fas fa-list"></i> On this page
+        </div>
+        {%- endif %}
+        <nav id="bd-toc-nav">
+            {{ generate_toc_html() }}
+        </nav>
     </div>
 </div>

--- a/tests/sites/base/index.md
+++ b/tests/sites/base/index.md
@@ -2,7 +2,9 @@
 
 ```{toctree}
 :caption: My caption
+:numbered:
 page1
 page2
 section1/index
+https://google.com
 ```

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -1,0 +1,52 @@
+<div class="col-12 col-md-3 bd-sidebar site-navigation show" id="site-navigation">
+ <div class="navbar-brand-box">
+  <a class="navbar-brand text-wrap" href="#">
+   <h1 class="site-logo" id="site-title">
+    Sphinx Book Theme  documentation
+   </h1>
+  </a>
+ </div>
+ <form action="search.html" class="bd-search d-flex align-items-center" method="get">
+  <i class="icon fas fa-search">
+  </i>
+  <input aria-label="Search the docs ..." autocomplete="off" class="form-control" id="search-input" name="q" placeholder="Search the docs ..." type="search"/>
+ </form>
+ <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+  <p class="caption">
+   <span class="caption-text">
+    My caption
+   </span>
+  </p>
+  <ul class="nav sidenav_l1">
+   <li class="toctree-l1">
+    <a class="reference internal" href="page1.html">
+     1. Page 1
+    </a>
+   </li>
+   <li class="toctree-l1">
+    <a class="reference internal" href="page2.html">
+     2. Page 2
+    </a>
+   </li>
+   <li class="toctree-l1">
+    <a class="reference internal" href="section1/index.html">
+     3. Section 1 index
+    </a>
+   </li>
+   <li class="toctree-l1">
+    <a class="reference external" href="https://google.com">
+     https://google.com
+     <i class="fas fa-external-link-alt">
+     </i>
+    </a>
+   </li>
+  </ul>
+ </nav>
+ <!-- To handle the deprecated key -->
+ <div class="navbar_extra_footer">
+  Theme by the
+  <a href="https://ebp.jupyterbook.org">
+   Executable Book Project
+  </a>
+ </div>
+</div>


### PR DESCRIPTION
This re-works the sidebar logic so that we're using the Sphinx `toctree` and `toc` objects instead of the custom pydata theme ones. This will introduce some unexpected behavior with numbering etc, but I think it's behavior we want because it brings it in-line with how other Sphinx themes will work.