### PR TITLE
Fixed font scaling for caption spans

### DIFF
--- a/sphinx_book_theme/static/sphinx-book-theme.scss
+++ b/sphinx_book_theme/static/sphinx-book-theme.scss
@@ -119,7 +119,7 @@ main.bd-content {
             }
 
             span {
-                font-size: .9em;
+                font-size: .9rem;
             }
         }
 


### PR DESCRIPTION
This PR fixes #131 by using root-scaling (rem) on caption spans.

It looks like the weird behavior I was seeing from mathjax was an artifact of hacking this behavior in the browser via the CSS editor after the math had already been rendered.  Having now fixed the scaling in the source css, mathjax behaves properly in both firefox and chromium for me.