### PR TITLE
🐛 BUG: improving tests and adding escaping for metadata

### DIFF
--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -14,7 +14,7 @@
 <!-- Opengraph tags -->
 <meta property="og:url"         content="{{ pageurl }}" />
 <meta property="og:type"        content="article" />
-<meta property="og:title"       content="{% if pagetitle %}{{ pagetitle }}{% else %}{{ docstitle }}{% endif %}" />
+<meta property="og:title"       content="{% if pagetitle %}{{ pagetitle | e }}{% else %}{{ docstitle | e }}{% endif %}" />
 <meta property="og:description" content="{{ page_description | e }}" />
 {% if logourl %}<meta property="og:image"       content="{{ logourl }}" />{% endif %}
 

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -15,10 +15,10 @@
 <meta property="og:url"         content="{{ pageurl }}" />
 <meta property="og:type"        content="article" />
 <meta property="og:title"       content="{% if pagetitle %}{{ pagetitle }}{% else %}{{ docstitle }}{% endif %}" />
-<meta property="og:description" content="{{ page_description }}" />
+<meta property="og:description" content="{{ page_description | e }}" />
 {% if logourl %}<meta property="og:image"       content="{{ logourl }}" />{% endif %}
 
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary" />
 {% endif %}
 {% endblock %}
 

--- a/tests/sites/base/conf.py
+++ b/tests/sites/base/conf.py
@@ -13,6 +13,7 @@ master_doc = "index"
 # ones.
 extensions = ["myst_nb", "sphinx_copybutton", "sphinx_togglebutton", "sphinx_thebe"]
 html_theme = "sphinx_book_theme"
+html_baseurl = "https://sphinx-book-theme.readthedocs.org"
 html_copy_source = True
 html_sourcelink_suffix = ""
 jupyter_execute_notebooks = "auto"

--- a/tests/sites/base/page1.md
+++ b/tests/sites/base/page1.md
@@ -1,1 +1,3 @@
 # Page 1
+
+Test content with <a href="https://google.com">Some raw HTML</a> to test.

--- a/tests/test_build/escaped_description.html
+++ b/tests/test_build/escaped_description.html
@@ -1,0 +1,1 @@
+<meta content='Page 1  Test content with &lt;a href="https://google.com"&gt;Some raw HTML&lt;/a&gt; to test.' property="og:description"/>


### PR DESCRIPTION
This fixes https://github.com/executablebooks/jupyter-book/issues/823 by escaping the `description` field of HTML metadata. Also improves some of our testing infrastructure so it's a bit more extensible