### PR TITLE
🐛 BUG: Create parent folders, when adding notebook to sources

### DIFF
--- a/sphinx_book_theme/launch.py
+++ b/sphinx_book_theme/launch.py
@@ -29,7 +29,7 @@ def add_hub_urls(app, pagename, templatename, context, doctree):
         path_ntbk = ntbk_dir.joinpath(pagename).with_suffix(".ipynb")
         path_new_notebook = sources_dir.joinpath(pagename).with_suffix(".ipynb")
         # Copy the notebook to `_sources` dir so it can be downloaded
-        path_new_notebook.parent.mkdir(exist_ok=True)
+        path_new_notebook.parent.mkdir(exist_ok=True, parents=True)
         copy2(path_ntbk, path_new_notebook)
         context["ipynb_source"] = pagename + ".ipynb"
 


### PR DESCRIPTION
Related to #151 

I ran:

```
$ # in a clean virtualenv
$ pip install -e '.[sphinx,testing]' --use-feature=2020-resolver
$ sphinx-build -b html docs/ build/docs -v
```

Upon running this, I was greeted with:

<details>

<summary>A traceback from Sphinx</summary>

```
Running Sphinx v2.4.4
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 24 source files that are out of date
updating environment: Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/reference/notebookpage1.ipynb
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/reference/notebookpage1.ipynb
Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base.ipynb
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base.ipynb
Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/reference/markdown_limits.md
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/reference/markdown_limits.md
Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/notebooks.md
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/notebooks.md
Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base.ipynb
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base.ipynb
Executing: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base.ipynb
Execution Succeeded: /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base.ipynb
[new config] 24 added, 24 changed, 0 removed
checking for /Users/pradyunsg/Projects/sphinx-book-theme/docs/references.bib in bibtex cache... not found                                 
parsing bibtex file /Users/pradyunsg/Projects/sphinx-book-theme/docs/references.bib... parsed 2 entries
executing markdown_limits reference/markdown_limits                                                                                       
reading sources... [100%] reference/subchapter1b/index                                                                                    
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base.ipynb: WARNING: document isn't included in any toctree
/Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base.ipynb: WARNING: document isn't included in any toctree
/Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base.ipynb: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [ 37%] notebooks                                                                                                        
Exception occurred:
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/pathlib.py", line 1284, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/pradyunsg/Projects/sphinx-book-theme/build/html/_sources'
The full traceback has been saved in /var/folders/4d/bt0_xfx56bjfmmt2bv3r5_qh0000gn/T/sphinx-err-dz6dgjyz.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
 ~  Projects  sphinx-book-theme   8% ─────────────────────────── 16:54:54  23.6s  sphinx-book-theme     properly-close-readme 
❯ g co master                                        
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
 ~  Projects  sphinx-book-theme   8% ────────────────────────────────────────────────── 16:55:09  sphinx-book-theme     master 
❯ g nb cleanup-linting-dependencies-commit-
 ~  Projects  sphinx-book-theme   8% ────────────────────────────────────────── 16:55:21  INT ✘  sphinx-book-theme     master 
❯ sphinx-build -b html docs/ build/docs -v
Running Sphinx v2.4.4
Adding copy buttons to code blocks...
Adding copy buttons to code blocks...
MyST-NB: Excluded Paths: set()
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 24 source files that are out of date
updating environment: MyST-NB: Potential docnames to execute: ['reference/subchapter1a/chapterpage1', 'reference/notebookpage1', 'contributing', 'configure', 'launch', 'reference/subchapter1b/index', 'reference/chapterpage3', 'index', 'reference/subchapter1a/index', 'notebooks', '.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base', 'reference/subchapter1b/chapterpage2', 'reference/chapterpage2', 'reference/chapterpage1', 'reference/index', 'reference/subchapter1a/chapterpage3', 'reference/subchapter1b/chapterpage3', '.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base', '.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base', 'reference/subchapter1b/chapterpage1', 'layout', 'reference/subchapter1a/chapterpage2', 'reference/markdown_limits']
[new config] 24 added, 24 changed, 0 removed
reading sources... [  4%] .jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base
Merged cached outputs into docs/.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base.ipynb
reading sources... [  8%] .jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base
Merged cached outputs into docs/.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base.ipynb
reading sources... [ 12%] .jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base
Merged cached outputs into docs/.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base.ipynb
reading sources... [ 16%] configure
reading sources... [ 20%] contributing
reading sources... [ 25%] index
reading sources... [ 29%] launch
reading sources... [ 33%] layout
reading sources... [ 37%] notebooks
Merged cached outputs into docs/notebooks.md
reading sources... [ 41%] reference/chapterpage1
reading sources... [ 45%] reference/chapterpage2
reading sources... [ 50%] reference/chapterpage3
reading sources... [ 54%] reference/demo
checking for /Users/pradyunsg/Projects/sphinx-book-theme/docs/references.bib in bibtex cache... not found
parsing bibtex file /Users/pradyunsg/Projects/sphinx-book-theme/docs/references.bib... parsed 2 entries
reading sources... [ 58%] reference/index
reading sources... [ 62%] reference/markdown_limits
Merged cached outputs into docs/reference/markdown_limits.md
executing markdown_limits
reading sources... [ 66%] reference/notebookpage1
Merged cached outputs into docs/reference/notebookpage1.ipynb
reading sources... [ 70%] reference/subchapter1a/chapterpage1
reading sources... [ 75%] reference/subchapter1a/chapterpage2
reading sources... [ 79%] reference/subchapter1a/chapterpage3
reading sources... [ 83%] reference/subchapter1a/index
reading sources... [ 87%] reference/subchapter1b/chapterpage1
reading sources... [ 91%] reference/subchapter1b/chapterpage2
reading sources... [ 95%] reference/subchapter1b/chapterpage3
reading sources... [100%] reference/subchapter1b/index

looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base.ipynb: WARNING: document isn't included in any toctree
/Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base.ipynb: WARNING: document isn't included in any toctree
/Users/pradyunsg/Projects/sphinx-book-theme/docs/.jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base.ipynb: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [  4%] .jupyter_cache/executed/3533598330d0b480ab0c0262f9759415/base
writing output... [  8%] .jupyter_cache/executed/88965405a747cf160c2100eb621e6628/base
writing output... [ 12%] .jupyter_cache/executed/f4063685691502a64bca1e9db9aa9aeb/base
writing output... [ 16%] configure
writing output... [ 20%] contributing
writing output... [ 25%] index
writing output... [ 29%] launch
writing output... [ 33%] layout
writing output... [ 37%] notebooks

Traceback (most recent call last):
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app.build(args.force_all, filenames)
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/application.py", line 349, in build
    self.builder.build_update()
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 297, in build_update
    self.build(to_build,
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 361, in build
    self.write(docnames, list(updated_docnames), method)
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 535, in write
    self._write_serial(sorted(docnames))
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 545, in _write_serial
    self.write_doc(docname, doctree)
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/html.py", line 618, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/builders/html.py", line 1017, in handle_page
    newtmpl = self.app.emit_firstresult('html-page-context', pagename,
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/application.py", line 456, in emit_firstresult
    return self.events.emit_firstresult(event, *args)
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/events.py", line 107, in emit_firstresult
    for result in self.emit(name, *args):
  File "/Users/pradyunsg/.virtualenvs/sphinx-book-theme/lib/python3.8/site-packages/sphinx/events.py", line 99, in emit
    results.append(callback(self.app, *args))
  File "/Users/pradyunsg/Projects/sphinx-book-theme/sphinx_book_theme/launch.py", line 32, in add_hub_urls
    path_new_notebook.parent.mkdir(exist_ok=True)
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/pathlib.py", line 1284, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/pradyunsg/Projects/sphinx-book-theme/build/html/_sources'

Exception occurred:
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/pathlib.py", line 1284, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/pradyunsg/Projects/sphinx-book-theme/build/html/_sources'
The full traceback has been saved in /var/folders/4d/bt0_xfx56bjfmmt2bv3r5_qh0000gn/T/sphinx-err-309f1vqs.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

</details>

Some debugging later, I could see that the issue was the "build/html" folder did not exist. I'm not a 100% sure *why* the theme's build pipeline tries to create that folder, but making it create the parent folders seems to make it work. That's what this patch does. :)
