### PR TITLE
🐛 BUG: backref superscript

### DIFF
--- a/sphinx_book_theme/static/sphinx-book-theme.scss
+++ b/sphinx_book_theme/static/sphinx-book-theme.scss
@@ -174,8 +174,8 @@ main.bd-content {
         dl.footnote {
 
             span.fn-backref {
-                font-size: .8em;
-                vertical-align: top;
+                font-size: 1em;
+                vertical-align: middle;
                 padding-left:.1em;
             }
 

--- a/sphinx_book_theme/static/sphinx-book-theme.scss
+++ b/sphinx_book_theme/static/sphinx-book-theme.scss
@@ -168,14 +168,12 @@ main.bd-content {
 
         .footnote-reference, a.bibtex.internal {
             font-size: 1em;
-            vertical-align: middle;
         }
 
         dl.footnote {
 
             span.fn-backref {
                 font-size: 1em;
-                vertical-align: middle;
                 padding-left:.1em;
             }
 


### PR DESCRIPTION
The following PR makes the backref inline instead of superscript.

cc @choldgraf 


fixes https://github.com/executablebooks/MyST-Parser/issues/196