### PR TITLE
🔧 MAINTAIN: downgrade nbclient to v0.2 for docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             "matplotlib",
             "ipywidgets",
             "pandas",
-            "nbclient",
+            "nbclient~=0.2.0",
             "myst-nb~=0.9.1",
             "sphinx-togglebutton>=0.2.1",
             "sphinx-copybutton",


### PR DESCRIPTION
We are seeing this issue on RTD: https://github.com/executablebooks/jupyter-book/issues/867