### PR TITLE
🐛 FIX: :align: for image directive

### DIFF
--- a/docs/reference/demo.rst
+++ b/docs/reference/demo.rst
@@ -379,6 +379,34 @@ An image directive (also clickable -- a hyperlink reference):
 .. image:: ../images/cool.jpg
    :target: directives_
 
+An image directive can be aligned using the option ``:align: right`` or ``:align: left``. By default, images are aligned to the center.
+
+.. code-block:: rst
+
+   .. image:: ../images/cool.jpg
+      :align: left
+
+.. image:: ../images/cool.jpg
+   :align: left
+
+.. raw:: html
+
+   <br/><br/><br/><br/><br/><br/>
+
+.. code-block:: rst
+
+   .. image:: ../images/cool.jpg
+      :align: right
+
+
+.. image:: ../images/cool.jpg
+   :align: right
+
+.. raw:: html
+
+   <br/><br/><br/><br/><br/>
+
+
 Figures
 ^^^^^^^
 

--- a/sphinx_book_theme/scss/sphinx-book-theme.scss
+++ b/sphinx_book_theme/scss/sphinx-book-theme.scss
@@ -81,6 +81,26 @@ main.bd-content {
             font-size: 1.2em;
         }
 
+        // Images
+        img {
+            display: block;
+            margin-right: auto;
+            margin-left: auto;
+
+            &.align-left {
+                clear: left;
+                float: left;
+                margin-right: 1em;
+
+            }
+
+            &.align-right {
+                clear: right;
+                float: right;
+                margin-left: 1em;
+            }
+        }
+
         // Figures
         div.figure {
             width: 100%;


### PR DESCRIPTION
This PR fixes the align option for image directives. I have set the default align behavior to center.