### PR TITLE
Add sphinx extensions to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
 matplotlib
 numpy
 folium
+myst-nb
+sphinx-copybutton
+sphinxcontrib-bibtex
+sphinx-thebe


### PR DESCRIPTION
This PR adds the following Sphinx extensions under `docs/requirements.txt`:
* myst-nb
* sphinx-copybutton
* sphinxcontrib-bibtex
* sphinx-thebe