### PR TITLE
👌 IMPROVE: Add missing aria-label to fullscreen button

### DIFF
--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -17,7 +17,8 @@
 
         <!-- Full screen (wrap in <a> to have style consistency -->
         <a class="full-screen-button"><button type="button" class="btn btn-secondary topbarbtn" data-toggle="tooltip"
-                data-placement="bottom" onclick="toggleFullScreen()" title="{{ translate('Fullscreen mode') }}"><i
+                data-placement="bottom" onclick="toggleFullScreen()" aria-label="{{ translate('Fullscreen mode') }}"
+                title="{{ translate('Fullscreen mode') }}"><i
                     class="fas fa-expand"></i></button></a>
 
         {% include "topbar/launchbuttons.html" %}


### PR DESCRIPTION
Google Lighthouse highlighted the lack of aria-label as an accessibility issue.
This PR adds an accessible label for the "Fullscreen mode" button.
