### PR TITLE
♻️ REFACTOR: Removed chevrons from captions when show_navbar_depth > 0

### DIFF
--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -167,6 +167,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
                         )
                     )
                 else:
+                    # Icon won't show up unless captions are collapsed
                     if not li.name == "p" and "caption" not in li["class"]:
                         li.append(
                             toctree.new_tag(

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -167,9 +167,12 @@ def add_to_context(app, pagename, templatename, context, doctree):
                         )
                     )
                 else:
-                    li.append(
-                        toctree.new_tag("i", attrs={"class": ["fas", "fa-chevron-up"]})
-                    )
+                    if not li.name == "p" and "caption" not in li["class"]:
+                        li.append(
+                            toctree.new_tag(
+                                "i", attrs={"class": ["fas", "fa-chevron-up"]}
+                            )
+                        )
 
         # for top-level caption's collapse functionality
         for para in toctree("p", attrs={"class": ["caption"]}):

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -16,8 +16,6 @@
    <span class="caption-text">
     My caption
    </span>
-   <i class="fas fa-chevron-up">
-   </i>
   </p>
   <ul class="nav sidenav_l1">
    <li class="toctree-l1">


### PR DESCRIPTION
when `show_navbar_depth` > 0 , the chevrons wont be visible for captions.

cc: @choldgraf 

fixes https://github.com/executablebooks/sphinx-book-theme/issues/235