### PR TITLE
🐛 FIX: Fix linking to autogenerated ipynb files from md.

### DIFF
--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -10,6 +10,9 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+
+execution:
+  timeout: None
 ---
 
 # Content with notebooks

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 
 execution:
-  timeout: None
+  timeout: 30
 ---
 
 # Content with notebooks

--- a/sphinx_book_theme/launch.py
+++ b/sphinx_book_theme/launch.py
@@ -40,7 +40,10 @@ def add_hub_urls(
         return
 
     # Check if we have a markdown notebook, and if so then add a link to the context
-    if _is_notebook(app, pagename) and context["sourcename"].endswith(".md"):
+    if _is_notebook(app, pagename) and (
+        context["sourcename"].endswith(".md")
+        or context["sourcename"].endswith(".md.txt")
+    ):
         # Figure out the folders we want
         build_dir = Path(app.outdir).parent
         ntbk_dir = build_dir.joinpath("jupyter_execute")


### PR DESCRIPTION
The conditional here was preventing this block from running as the md files in `_source/` had `.txt` appended to them during the build process (in my case at least). I wasn't sure if this was *always* the case so I modified the conditional to account for both possibilities.