### PR TITLE
👌 IMPROVE: Making in-page TOC title configurable

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -152,6 +152,18 @@ html_sidebars = {
 
 See the [Sphinx HTML sidebars documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars) for more information.
 
+## Rename the right sidebar title
+
+You can rename the title of the in-page table of contents, in the right sidebar:
+
+```python
+html_theme_options = {
+    "toc_title": "{your-title}"
+}
+```
+
+The deafult value of the title is `Contents`.
+
 ### Default sidebar elements
 
 By default, this theme comes with these three theme-specific sidebar elements enabled on all pages:

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -127,6 +127,17 @@ html_theme_options = {
 }
 ```
 
+## Control the right sidebar items
+
+You can rename the title of the in-page table of contents, in the right sidebar:
+
+```python
+html_theme_options = {
+    "toc_title": "{your-title}"
+}
+```
+
+The deafult value of the title is `Contents`.
 
 ## Control the left sidebar items
 
@@ -151,18 +162,6 @@ html_sidebars = {
 ```
 
 See the [Sphinx HTML sidebars documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars) for more information.
-
-## Rename the right sidebar title
-
-You can rename the title of the in-page table of contents, in the right sidebar:
-
-```python
-html_theme_options = {
-    "toc_title": "{your-title}"
-}
-```
-
-The deafult value of the title is `Contents`.
 
 ### Default sidebar elements
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -137,7 +137,7 @@ html_theme_options = {
 }
 ```
 
-The deafult value of the title is `Contents`.
+The default value of the title is `Contents`.
 
 ## Control the left sidebar items
 

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -257,7 +257,8 @@ def add_to_context(app, pagename, templatename, context, doctree):
 
         out = f"""
         <div class="tocsection onthispage pt-5 pb-3">
-            <i class="fas fa-list"></i> { context["theme_toc_title"] }
+            <i class="fas fa-list"></i>
+            { context["translate"](context["theme_toc_title"]) }
         </div>
         <nav id="bd-toc-nav">
             {toc_out}

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -250,9 +250,14 @@ def add_to_context(app, pagename, templatename, context, doctree):
         else:
             toc_out = soup.prettify()
 
+        if not context["theme_toc_title"]:
+            raise ValueError(
+                "`toc_title` cannot be empty. Please set a non-empty value."
+            )
+
         out = f"""
         <div class="tocsection onthispage pt-5 pb-3">
-            <i class="fas fa-list"></i> { context["translate"]('Contents') }
+            <i class="fas fa-list"></i> { context["theme_toc_title"] }
         </div>
         <nav id="bd-toc-nav">
             {toc_out}

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -252,7 +252,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
 
         if not context["theme_toc_title"]:
             raise ValueError(
-                "`toc_title` cannot be empty. Please set a non-empty value."
+                "'toc_title' key cannot be empty. Please set a non-empty value."
             )
 
         out = f"""

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -21,3 +21,4 @@ use_download_button = True
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
+toc_title = "Contents"

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -21,4 +21,4 @@ use_download_button = True
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
-toc_title = "Contents"
+toc_title = Contents

--- a/src/jinja/theme.conf
+++ b/src/jinja/theme.conf
@@ -20,4 +20,4 @@ use_issues_button = False
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
-toc_title = "Contents"
+toc_title = Contents

--- a/src/jinja/theme.conf
+++ b/src/jinja/theme.conf
@@ -20,3 +20,4 @@ use_issues_button = False
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
+toc_title = "Contents"

--- a/src/jinja/theme.conf.j2
+++ b/src/jinja/theme.conf.j2
@@ -21,3 +21,4 @@ use_download_button = True
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
+toc_title = "Contents"

--- a/src/jinja/theme.conf.j2
+++ b/src/jinja/theme.conf.j2
@@ -21,4 +21,4 @@ use_download_button = True
 use_repository_button = False
 theme_dev_mode = False
 show_navbar_depth = 1
-toc_title = "Contents"
+toc_title = Contents

--- a/tests/sites/base/page1.md
+++ b/tests/sites/base/page1.md
@@ -1,3 +1,11 @@
 # Page 1
 
 Test content with <a href="https://google.com">Some raw HTML</a> to test.
+
+## Section 1
+
+First section
+
+## Section 2
+
+Second section

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -300,3 +300,16 @@ def test_topbar_download_button_off(sphinx_build_factory, file_regression):
         "div", attrs={"class": "topbar-main"}
     )[0]
     file_regression.check(source_btns.prettify(), extension=".html", encoding="utf8")
+
+
+def test_right_sidebar_title(sphinx_build_factory, file_regression):
+    confoverrides = {"html_theme_options.toc_title": "My Contents"}
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build(
+        assert_pass=True
+    )
+
+    sidebar_title = sphinx_build.html_tree("page1.html").find_all(
+        "div", attrs={"class": "tocsection"}
+    )[0]
+
+    file_regression.check(sidebar_title.prettify(), extension=".html", encoding="utf8")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from shutil import copytree
+from shutil import copytree, rmtree
 from subprocess import check_call
 
 from bs4 import BeautifulSoup
@@ -313,3 +313,13 @@ def test_right_sidebar_title(sphinx_build_factory, file_regression):
     )[0]
 
     file_regression.check(sidebar_title.prettify(), extension=".html", encoding="utf8")
+
+    # Testing the exception for empty title
+    rmtree(str(sphinx_build.src))
+
+    confoverrides = {"html_theme_options.toc_title": ""}
+
+    with pytest.raises(
+        ThemeError, match="key cannot be empty. Please set a non-empty value."
+    ):
+        sphinx_build_factory("base", confoverrides=confoverrides).build()

--- a/tests/test_build/escaped_description.html
+++ b/tests/test_build/escaped_description.html
@@ -1,1 +1,1 @@
-<meta content='Page 1  Test content with &lt;a href="https://google.com"&gt;Some raw HTML&lt;/a&gt; to test.' property="og:description"/>
+<meta content='Page 1  Test content with &lt;a href="https://google.com"&gt;Some raw HTML&lt;/a&gt; to test.  Section 1  First section  Section 2  Second sectionSection 1  First sectionSe' property="og:description"/>

--- a/tests/test_build/test_right_sidebar_title.html
+++ b/tests/test_build/test_right_sidebar_title.html
@@ -1,0 +1,5 @@
+<div class="tocsection onthispage pt-5 pb-3">
+ <i class="fas fa-list">
+ </i>
+ My Contents
+</div>


### PR DESCRIPTION
This PR makes in-page TOC title configurable with the introduction of the following key:
```
html_theme_options = {
	"toc_title": "Some other title",
}
```

The default value of the title has been kept as `Contents`.

It will throw an error if the title is set to empty (I reckon a title is always necessary?)

@choldgraf is there any exception handling format we need to follow for this repo. or the way I have handled it is ok?

fixes https://github.com/executablebooks/sphinx-book-theme/issues/297