### PR TITLE
👌 IMPROVE: Master doc title specified in `_toc.yml` is visible in left-sidebar

### DIFF
--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -125,6 +125,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
             master_doc = config["master_doc"]
             master_doctree = app.env.get_doctree(master_doc)
             master_url = context["pathto"](master_doc)
+            # check for title in `_toc.yml` else get title from doctree
             master_title = app.config["globaltoc"].get("title") or list(
                 master_doctree.traverse(nodes.title)
             )

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -125,8 +125,8 @@ def add_to_context(app, pagename, templatename, context, doctree):
             master_doc = config["master_doc"]
             master_doctree = app.env.get_doctree(master_doc)
             master_url = context["pathto"](master_doc)
-            # check for title in `_toc.yml` (jb projects) else get title from doctree
             try:
+                # check title in `_toc.yml` (jb projects) else get title from doctree
                 master_title = app.config["globaltoc"].get("title")
                 if not master_title:
                     raise ValueError()

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -14,6 +14,7 @@ from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.locale import get_translation
 from sphinx.util import logging
+from contextlib import suppress
 
 from .launch import add_hub_urls
 from . import static as theme_static
@@ -125,12 +126,13 @@ def add_to_context(app, pagename, templatename, context, doctree):
             master_doc = config["master_doc"]
             master_doctree = app.env.get_doctree(master_doc)
             master_url = context["pathto"](master_doc)
-            try:
-                # check title in `_toc.yml` (jb projects) else get title from doctree
+
+            # check title in globaltoc (jb case) else get title from doctree
+            master_title = None
+            with suppress(Exception):
                 master_title = app.config["globaltoc"].get("title")
-                if not master_title:
-                    raise ValueError()
-            except ValueError:
+
+            if not master_title:
                 master_title = list(master_doctree.traverse(nodes.title))
                 if len(master_title) == 0:
                     raise ValueError(f"Landing page missing a title: {master_doc}")

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -125,10 +125,13 @@ def add_to_context(app, pagename, templatename, context, doctree):
             master_doc = config["master_doc"]
             master_doctree = app.env.get_doctree(master_doc)
             master_url = context["pathto"](master_doc)
-            master_title = list(master_doctree.traverse(nodes.title))
-            if len(master_title) == 0:
-                raise ValueError(f"Landing page missing a title: {master_doc}")
-            master_title = master_title[0].astext()
+            master_title = app.config["globaltoc"].get("title") or list(
+                master_doctree.traverse(nodes.title)
+            )
+            if isinstance(master_title, list):
+                if len(master_title) == 0:
+                    raise ValueError(f"Landing page missing a title: {master_doc}")
+                master_title = master_title[0].astext()
             li_class = "toctree-l1"
             if context["pagename"] == master_doc:
                 li_class += " current"

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -125,14 +125,17 @@ def add_to_context(app, pagename, templatename, context, doctree):
             master_doc = config["master_doc"]
             master_doctree = app.env.get_doctree(master_doc)
             master_url = context["pathto"](master_doc)
-            # check for title in `_toc.yml` else get title from doctree
-            master_title = app.config["globaltoc"].get("title") or list(
-                master_doctree.traverse(nodes.title)
-            )
-            if isinstance(master_title, list):
+            # check for title in `_toc.yml` (jb projects) else get title from doctree
+            try:
+                master_title = app.config["globaltoc"].get("title")
+                if not master_title:
+                    raise ValueError()
+            except ValueError:
+                master_title = list(master_doctree.traverse(nodes.title))
                 if len(master_title) == 0:
                     raise ValueError(f"Landing page missing a title: {master_doc}")
                 master_title = master_title[0].astext()
+
             li_class = "toctree-l1"
             if context["pagename"] == master_doc:
                 li_class += " current"


### PR DESCRIPTION
As outlined in this issue https://github.com/executablebooks/jupyter-book/issues/1012 ,  master_doc title specified with `title` key in `_toc.yml` was not reflecting in the left sidebar. This PR fixes that.

Example:
```
- file: intro
  title: This is the intro
   ....
   ....
```

results in:-

<img width="266" alt="Screen Shot 2021-03-18 at 2 40 00 pm" src="https://user-images.githubusercontent.com/6542997/111569972-e5fa7380-87f7-11eb-89bc-ea640ac84378.png">

@choldgraf, the test infrastructure in this repo uses sphinx-build as it is `jb` agnostic. So, I won't be able to test this feature( which is directed only towards jb projects) here right? 


fixes https://github.com/executablebooks/jupyter-book/issues/1012
