### PR TITLE
Fix: Navigation Labelling

### DIFF
--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -260,7 +260,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
             <i class="fas fa-list"></i>
             { context["translate"](context["theme_toc_title"]) }
         </div>
-        <nav id="bd-toc-nav">
+        <nav id="bd-toc-nav", aria-label="Page">
             {toc_out}
         </nav>
         """

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -260,7 +260,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
             <i class="fas fa-list"></i>
             { context["translate"](context["theme_toc_title"]) }
         </div>
-        <nav id="bd-toc-nav", aria-label="Page">
+        <nav id="bd-toc-nav" aria-label="Page">
             {toc_out}
         </nav>
         """

--- a/sphinx_book_theme/_templates/sbt-sidebar-nav.html
+++ b/sphinx_book_theme/_templates/sbt-sidebar-nav.html
@@ -1,3 +1,3 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main">
     {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc) }}
 </nav>

--- a/tests/test_build/page-multipletitles.html
+++ b/tests/test_build/page-multipletitles.html
@@ -4,7 +4,7 @@
   </i>
   Contents
  </div>
- <nav id="bd-toc-nav">
+ <nav ,="" aria-label="Page" id="bd-toc-nav">
   <ul class="nav section-nav flex-column">
    <li class="toc-h1 nav-item toc-entry">
     <a class="reference internal nav-link" href="#">

--- a/tests/test_build/page-multipletitles.html
+++ b/tests/test_build/page-multipletitles.html
@@ -4,7 +4,7 @@
   </i>
   Contents
  </div>
- <nav ,="" aria-label="Page" id="bd-toc-nav">
+ <nav aria-label="Page" id="bd-toc-nav">
   <ul class="nav section-nav flex-column">
    <li class="toc-h1 nav-item toc-entry">
     <a class="reference internal nav-link" href="#">

--- a/tests/test_build/page-onetitle.html
+++ b/tests/test_build/page-onetitle.html
@@ -4,7 +4,7 @@
   </i>
   Contents
  </div>
- <nav ,="" aria-label="Page" id="bd-toc-nav">
+ <nav aria-label="Page" id="bd-toc-nav">
   <ul class="nav section-nav flex-column">
    <li class="toc-h2 nav-item toc-entry">
     <a class="reference internal nav-link" href="#here-s-a-sub-heading">

--- a/tests/test_build/page-onetitle.html
+++ b/tests/test_build/page-onetitle.html
@@ -4,7 +4,7 @@
   </i>
   Contents
  </div>
- <nav id="bd-toc-nav">
+ <nav ,="" aria-label="Page" id="bd-toc-nav">
   <ul class="nav section-nav flex-column">
    <li class="toc-h2 nav-item toc-entry">
     <a class="reference internal nav-link" href="#here-s-a-sub-heading">

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -11,7 +11,7 @@
   </i>
   <input aria-label="Search the docs ..." autocomplete="off" class="form-control" id="search-input" name="q" placeholder="Search the docs ..." type="search"/>
  </form>
- <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+ <nav aria-label="Main" class="bd-links" id="bd-docs-nav">
   <p class="caption collapsible-parent">
    <span class="caption-text">
     My caption


### PR DESCRIPTION
Fix for issue #308.

Changed labelling of "Main navigation" to "Main". Screen readers will now read this as "Main navigation".

Also added "Page" label to the page navigation. Screen readers will now read "Page navigation", differentiating this from the main navigation element.

To test:
- Using VoiceOver screenreader access Rotor (control-option-U)
- Use left/right arrow keys to navigate to "Landmarks"
- You should be able to see Main navigation, main, and Page navigation elements.