### PR TITLE
DEPRECATE: Removing opengraph functionality

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "ablog",
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -117,7 +118,6 @@ html_theme_options = {
     # "extra_footer": "<a href='https://google.com'>Test</a>",  # DEPRECATED KEY
     # "extra_navbar": "<a href='https://google.com'>Test</a>",
 }
-html_baseurl = "https://sphinx-book-theme.readthedocs.io/en/latest/"
 
 # -- ABlog config -------------------------------------------------
 blog_path = "reference/blog"

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -206,26 +206,6 @@ html_favicon = "path/to/favicon.ico"
 These will be placed in the top-left of your page.
 
 
-## Add metadata open graph tags to your site
-
-OpenGraph tags can be used to generate previews and descriptions of your
-website. These will be automatically generated based on your page's content
-and title. However, generating them requires knowing the full URL of your
-website ahead of time.
-
-To enable metadata tags for your documentation, use the following
-configuration in `conf.py`:
-
-```python
-html_baseurl = "https://<your-site-baseurl>"
-```
-
-For example, the value of this field for this documentation is:
-
-```python
-html_baseurl = "https://sphinx-book-theme.readthedocs.io/en/latest/"
-```
-
 ## Control the depth of the left sidebar lists to expand
 
 You can control the level of toc items in the left sidebar to remain expanded,

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
             "sphinxcontrib-bibtex~=2.2",
             "sphinx-thebe",
             "ablog~=0.10.13",
+            "sphinxext-opengraph",
         ],
         "testing": [
             "myst_nb~=0.11.1",

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -200,13 +200,6 @@ def add_to_context(app, pagename, templatename, context, doctree):
     if app.config.author != "unknown":
         context["author"] = app.config.author
 
-    # Absolute URLs for logo if `html_baseurl` is given
-    # pageurl will already be set by Sphinx if so
-    if app.config.html_baseurl and app.config.html_logo:
-        context["logourl"] = "/".join(
-            (app.config.html_baseurl.rstrip("/"), "_static/" + context["logo"])
-        )
-
     # Add HTML context variables that the pydata theme uses that we configure elsewhere
     # For some reason the source_suffix sometimes isn't there even when doctree is
     if doctree and context.get("page_source_suffix"):

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -7,21 +7,6 @@
     {%- set sidebar_width_class = "col-md-3" %}
 {% endif %}
 
-{% block extrahead %}
-{{ super() }}
-
-{% if pageurl %}
-<!-- Opengraph tags -->
-<meta property="og:url"         content="{{ pageurl }}" />
-<meta property="og:type"        content="article" />
-<meta property="og:title"       content="{% if pagetitle %}{{ pagetitle | e }}{% else %}{{ docstitle | e }}{% endif %}" />
-<meta property="og:description" content="{{ page_description | e }}" />
-{% if logourl %}<meta property="og:image"       content="{{ logourl }}" />{% endif %}
-
-<meta name="twitter:card" content="summary" />
-{% endif %}
-{% endblock %}
-
 <!-- Docs TOC is "d-none d-xl-block col-xl-2" -->
 
 {% block docs_sidebar %}

--- a/tests/sites/base/conf.py
+++ b/tests/sites/base/conf.py
@@ -13,7 +13,6 @@ master_doc = "index"
 # ones.
 extensions = ["myst_nb", "sphinx_thebe"]
 html_theme = "sphinx_book_theme"
-html_baseurl = "https://sphinx-book-theme.readthedocs.org"
 html_copy_source = True
 html_sourcelink_suffix = ""
 jupyter_execute_notebooks = "auto"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -87,11 +87,6 @@ def test_build_book(sphinx_build_factory, file_regression):
     sidebar = index_html.find_all(attrs={"class": "bd-sidebar"})[0]
     file_regression.check(sidebar.prettify(), extension=".html", encoding="utf8")
 
-    # Opengraph should not be in the HTML because we have no baseurl specified
-    assert (
-        '<meta property="og:url"         content="https://blah.com/foo/section1/ntbk.html" />'  # noqa E501
-        not in str(index_html)
-    )
     # Edit button should not be on page
     assert '<a class="edit-button"' not in str(index_html)
     # Title should be just text, no HTML
@@ -103,15 +98,6 @@ def test_build_book(sphinx_build_factory, file_regression):
     # Pages and sub-pages should be numbered
     assert "1. Page 1" in str(sidebar_ntbk)
     assert "3.1. Section 1 page1" in str(sidebar_ntbk)
-    # Check opengraph metadata
-    html_escaped = sphinx_build.html_tree("page1.html")
-    escaped_description = html_escaped.find("meta", property="og:description")
-    file_regression.check(
-        escaped_description.prettify(),
-        basename="escaped_description",
-        extension=".html",
-        encoding="utf8",
-    )
 
     # Test that the TOCtree is rendered properly across different title arrangements
     for page in sphinx_build.outdir.joinpath("titles").rglob("**/page-*"):
@@ -173,29 +159,6 @@ def test_navbar_options(sphinx_build_factory, option, value):
         assert_pass=True
     )  # type: SphinxBuild
     assert value in str(sphinx_build.html_tree("section1", "ntbk.html"))
-
-
-def test_header_info(sphinx_build_factory):
-    confoverrides = {
-        "html_baseurl": "https://blah.com/foo/",
-        "html_logo": os.path.abspath(
-            path_tests.parent.joinpath("docs", "_static", "logo.png")
-        ),
-    }
-    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build(
-        assert_pass=True
-    )
-
-    # opengraph is generated when baseurl is given
-    header = sphinx_build.html_tree("section1", "ntbk.html").find("head")
-    assert (
-        '<meta content="https://blah.com/foo/section1/ntbk.html" property="og:url"/>'
-        in str(header)
-    )
-    assert (
-        '<meta content="https://blah.com/foo/_static/logo.png" property="og:image"/>'
-        in str(header)
-    )
 
 
 def test_topbar_edit_buttons_on(sphinx_build_factory, file_regression):

--- a/tests/test_build/escaped_description.html
+++ b/tests/test_build/escaped_description.html
@@ -1,1 +1,0 @@
-<meta content='Page 1  Test content with &lt;a href="https://google.com"&gt;Some raw HTML&lt;/a&gt; to test.  Section 1  First section  Section 2  Second sectionSection 1  First sectionSe' property="og:description"/>


### PR DESCRIPTION
This removes OpenGraph functionality from this theme, because the [sphinext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) package is a much better way of accomplishing this than using a hard-code in a theme.