### PR TITLE
Fixing path to '_sources' directory when using builders besides 'html'

### DIFF
--- a/sphinx_book_theme/launch.py
+++ b/sphinx_book_theme/launch.py
@@ -47,7 +47,7 @@ def add_hub_urls(
         # Figure out the folders we want
         build_dir = Path(app.outdir).parent
         ntbk_dir = build_dir.joinpath("jupyter_execute")
-        sources_dir = build_dir.joinpath("html", "_sources")
+        sources_dir = build_dir.joinpath(context.get("builder", "html"), "_sources")
         # Paths to old and new notebooks
         path_ntbk = ntbk_dir.joinpath(pagename).with_suffix(".ipynb")
         path_new_notebook = sources_dir.joinpath(pagename).with_suffix(".ipynb")


### PR DESCRIPTION
Moments after opening #338, I found the fix. When copying the `.ipynb` files, the destination path was hard coded as `html`, but should depend on the `builder` setting in `context`. I've tested that this fixes my use case, but let me know if it would be good to explicitly include a test!

Closes #338 