### PR TITLE
Remove pre-commit job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,6 @@ on:
   pull_request:
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - uses: pre-commit/action@v2.0.0
 
   tests:
     strategy:
@@ -52,7 +44,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [pre-commit, tests]
+    needs: [tests]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This removes the pre-commit job from our CI/CD, since we now use pre-commit.ci to auto-update PRs.

# Question

There is one way in which pre-commit.ci does not replace our old workflow, which is **using the pre-commit job as a pre-requisite for publishing a package**. We have our PyPI publishing step "depending on" the pre-commit job succeeding, but I don't believe we can build dependencies between a GHA job and a non-GHA job.

On the one hand, this removes an extra QA check before publishing, on the other hand, as long as the "version bump" commit process is followed (by creating a PR on master) and tests pass before the GitHub tag step, then we'll have an up-to-date pre-commit pass anyway.

So the question is:

- Is it OK that we remove this CI/CD job from our repository? Are we confident that the current pre-commit.ci workflow will still ensure QA in our releases?