### PR TITLE
📚 DOCS: Add reference for html_theme_options

### DIFF
--- a/docs/customize/index.md
+++ b/docs/customize/index.md
@@ -1,7 +1,36 @@
 # Customization
 
 These sections describe a few ways that you may customize the look and feel of your theme.
-See the sections below for more information.
+
+## Theme options
+
+The following options are available via `html_theme_options`
+
+% Generated from https://www.tablesgenerator.com/markdown_tables#
+% If you make edits, consider pasting there and re-generating the table so it's nicely formatted
+
+| Key                     | Type | Description                                                                                                                                                                 |
+|-------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `single_page`           | bool        | Remove the left sidebar and treat the site as a single page. See [](customize:single-page).                                                                                 |
+| `path_to_docs`          | string      | Path to the documentation, relative to the repository root (e.g. `docs/`). See [](customize:source-files).                                                                  |
+| `repository_url`        | string      | URL of the repository for the documentation (e.g. the GitHub repository URL). See [](source-files:repository).                                                              |
+| `repository_branch`     | string      | Branch of the repository for the documentation (e.g., `master`, `main`, `docs`). See [](source-files:repository).                                                           |
+| `use_issues_button`     | bool        | Add an button in the topbar with a link to issues for the repository (used in conjunction with `repository_url` and `repository_branch`). See  [](source-files:repository). |
+| `use_download_button`   | bool        | Add a button in the topbar to download the source file of the page. See [](customize:source-files).                                                                         |
+| `use_fullscreen_button` | bool        | Add a button in the topbar to trigger full-screen mode.                                                                                                                     |
+| `use_repository_button` | bool        | Add a button in the topbar that links to the repository of the documentation.See [](source-files:repository).                                                               |
+| `launch_buttons`        | bool        | Include Binder launch buttons for pages that were built from Jupyter Notebooks. See [](customize:launch).                                                                   |
+| `home_page_in_toc`      | bool        | Whether to put the home page in the Navigation Bar (at the top). See [](sidebar-primary:home-page).                                                                         |
+| `logo_only`             | bool        | Only display the logo, not `html_title` if it exists.                                                                                                                       |
+| `show_navbar_depth`     | int         | Show children in the navigation bar down to the depth listed here. See [](sidebar:navbar-depth).                                                                            |
+| `extra_navbar`          | str         | Extra HTML to add below the sidebar footer (if `sbt-sidebar-footer.html` is used in `html_sidebars`). See [](custom-footer).                                                |
+| `extra_footer`          | str         | Extra HTML to add in the footer of each page.                                                                                                                               |
+| `toc_title`             | str         | The text to be displayed with the in-page TOC (`Contents` is default)                                                                                                       |
+| `theme_dev_mode`        | bool        | (developers only) Trigger some features that make it easier to develop the theme.                                                                                           |                                                                  |
+
+## Customization Topics
+
+The following sections describe a few ways to customize the theme in more depth.
 
 ```{toctree}
 sidebar-primary.md

--- a/docs/customize/index.md
+++ b/docs/customize/index.md
@@ -6,27 +6,61 @@ These sections describe a few ways that you may customize the look and feel of y
 
 The following options are available via `html_theme_options`
 
-% Generated from https://www.tablesgenerator.com/markdown_tables#
-% If you make edits, consider pasting there and re-generating the table so it's nicely formatted
-
-| Key                     | Type | Description                                                                                                                                                                 |
-|-------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `single_page`           | bool        | Remove the left sidebar and treat the site as a single page. See [](customize:single-page).                                                                                 |
-| `path_to_docs`          | string      | Path to the documentation, relative to the repository root (e.g. `docs/`). See [](customize:source-files).                                                                  |
-| `repository_url`        | string      | URL of the repository for the documentation (e.g. the GitHub repository URL). See [](source-files:repository).                                                              |
-| `repository_branch`     | string      | Branch of the repository for the documentation (e.g., `master`, `main`, `docs`). See [](source-files:repository).                                                           |
-| `use_issues_button`     | bool        | Add an button in the topbar with a link to issues for the repository (used in conjunction with `repository_url` and `repository_branch`). See  [](source-files:repository). |
-| `use_download_button`   | bool        | Add a button in the topbar to download the source file of the page. See [](customize:source-files).                                                                         |
-| `use_fullscreen_button` | bool        | Add a button in the topbar to trigger full-screen mode.                                                                                                                     |
-| `use_repository_button` | bool        | Add a button in the topbar that links to the repository of the documentation.See [](source-files:repository).                                                               |
-| `launch_buttons`        | bool        | Include Binder launch buttons for pages that were built from Jupyter Notebooks. See [](customize:launch).                                                                   |
-| `home_page_in_toc`      | bool        | Whether to put the home page in the Navigation Bar (at the top). See [](sidebar-primary:home-page).                                                                         |
-| `logo_only`             | bool        | Only display the logo, not `html_title` if it exists.                                                                                                                       |
-| `show_navbar_depth`     | int         | Show children in the navigation bar down to the depth listed here. See [](sidebar:navbar-depth).                                                                            |
-| `extra_navbar`          | str         | Extra HTML to add below the sidebar footer (if `sbt-sidebar-footer.html` is used in `html_sidebars`). See [](custom-footer).                                                |
-| `extra_footer`          | str         | Extra HTML to add in the footer of each page.                                                                                                                               |
-| `toc_title`             | str         | The text to be displayed with the in-page TOC (`Contents` is default)                                                                                                       |
-| `theme_dev_mode`        | bool        | (developers only) Trigger some features that make it easier to develop the theme.                                                                                           |                                                                  |
+```{list-table}
+:widths: 10 5 40
+:header-rows: 1
+* - Key
+  - Type
+  - Description
+* - `single_page`
+  - bool
+  - Remove the left sidebar and treat the site as a single page. See [](customize:single-page).
+* - `path_to_docs`          
+  - string      
+  - Path to the documentation, relative to the repository root (e.g. `docs/`). See [](customize:source-files).
+* - `repository_url`        
+  - string      
+  - URL of the repository for the documentation (e.g. the GitHub repository URL). See [](source-files:repository).
+* - `repository_branch`     
+  - string      
+  - Branch of the repository for the documentation (e.g., `master`, `main`, `docs`). See [](source-files:repository).
+* - `use_issues_button`     
+  - bool        
+  - Add an button in the topbar with a link to issues for the repository (used in conjunction with `repository_url` and `repository_branch`). See  [](source-files:repository).
+* - `use_download_button`   
+  - bool        
+  - Add a button in the topbar to download the source file of the page. See [](customize:source-files).
+* - `use_fullscreen_button` 
+  - bool        
+  - Add a button in the topbar to trigger full-screen mode.
+* - `use_repository_button` 
+  - bool        
+  - Add a button in the topbar that links to the repository of the documentation.See [](source-files:repository).
+* - `launch_buttons`        
+  - bool        
+  - Include Binder launch buttons for pages that were built from Jupyter Notebooks. See [](customize:launch).
+* - `home_page_in_toc`      
+  - bool        
+  - Whether to put the home page in the Navigation Bar (at the top). See [](sidebar-primary:home-page).
+* - `logo_only`             
+  - bool        
+  - Only display the logo, not `html_title` if it exists.
+* - `show_navbar_depth`     
+  - int         
+  - Show children in the navigation bar down to the depth listed here. See [](sidebar:navbar-depth).
+* - `extra_navbar`          
+  - str         
+  - Extra HTML to add below the sidebar footer (if `sbt-sidebar-footer.html` is used in `html_sidebars`). See [](custom-footer
+* - `extra_footer`          
+  - str         
+  - Extra HTML to add in the footer of each page.
+* - `toc_title`             
+  - str         
+  - The text to be displayed with the in-page TOC (`Contents` is default)
+* - `theme_dev_mode`        
+  - bool        
+  - (developers only) Trigger some features that make it easier to develop the theme.                  
+```
 
 ## Customization Topics
 

--- a/docs/customize/index.md
+++ b/docs/customize/index.md
@@ -15,51 +15,51 @@ The following options are available via `html_theme_options`
 * - `single_page`
   - bool
   - Remove the left sidebar and treat the site as a single page. See [](customize:single-page).
-* - `path_to_docs`          
-  - string      
+* - `path_to_docs`
+  - string
   - Path to the documentation, relative to the repository root (e.g. `docs/`). See [](customize:source-files).
-* - `repository_url`        
-  - string      
+* - `repository_url`
+  - string
   - URL of the repository for the documentation (e.g. the GitHub repository URL). See [](source-files:repository).
-* - `repository_branch`     
-  - string      
+* - `repository_branch`
+  - string
   - Branch of the repository for the documentation (e.g., `master`, `main`, `docs`). See [](source-files:repository).
-* - `use_issues_button`     
-  - bool        
+* - `use_issues_button`
+  - bool
   - Add an button in the topbar with a link to issues for the repository (used in conjunction with `repository_url` and `repository_branch`). See  [](source-files:repository).
-* - `use_download_button`   
-  - bool        
+* - `use_download_button`
+  - bool
   - Add a button in the topbar to download the source file of the page. See [](customize:source-files).
-* - `use_fullscreen_button` 
-  - bool        
+* - `use_fullscreen_button`
+  - bool
   - Add a button in the topbar to trigger full-screen mode.
-* - `use_repository_button` 
-  - bool        
+* - `use_repository_button`
+  - bool
   - Add a button in the topbar that links to the repository of the documentation.See [](source-files:repository).
-* - `launch_buttons`        
-  - bool        
+* - `launch_buttons`
+  - bool
   - Include Binder launch buttons for pages that were built from Jupyter Notebooks. See [](customize:launch).
-* - `home_page_in_toc`      
-  - bool        
+* - `home_page_in_toc`
+  - bool
   - Whether to put the home page in the Navigation Bar (at the top). See [](sidebar-primary:home-page).
-* - `logo_only`             
-  - bool        
+* - `logo_only`
+  - bool
   - Only display the logo, not `html_title` if it exists.
-* - `show_navbar_depth`     
-  - int         
+* - `show_navbar_depth`
+  - int
   - Show children in the navigation bar down to the depth listed here. See [](sidebar:navbar-depth).
-* - `extra_navbar`          
-  - str         
+* - `extra_navbar`
+  - str
   - Extra HTML to add below the sidebar footer (if `sbt-sidebar-footer.html` is used in `html_sidebars`). See [](custom-footer
-* - `extra_footer`          
-  - str         
+* - `extra_footer`
+  - str
   - Extra HTML to add in the footer of each page.
-* - `toc_title`             
-  - str         
+* - `toc_title`
+  - str
   - The text to be displayed with the in-page TOC (`Contents` is default)
-* - `theme_dev_mode`        
-  - bool        
-  - (developers only) Trigger some features that make it easier to develop the theme.                  
+* - `theme_dev_mode`
+  - bool
+  - (developers only) Trigger some features that make it easier to develop the theme.
 ```
 
 ## Customization Topics

--- a/docs/customize/sidebar-primary.md
+++ b/docs/customize/sidebar-primary.md
@@ -81,6 +81,7 @@ html_theme_options = {
 }
 ```
 
+(sidebar-primary:home-page)=
 ## Add the home page to your table of contents
 
 By default, your table of contents will begin with the first file that you add to a `toctree`. You can also configure the theme to show the **landing page** of the theme in your navigation bar as well.
@@ -95,6 +96,7 @@ html_theme_options = {
 }
 ```
 
+(sidebar:navbar-depth)=
 ## Control the depth of the left sidebar lists to expand
 
 You can control the level of toc items in the left sidebar to remain expanded,

--- a/docs/customize/single-page.md
+++ b/docs/customize/single-page.md
@@ -1,4 +1,4 @@
-
+(customize:single-page)=
 # Use a single-page version of this theme
 
 If your documentation only has a single page, and you don't need the left

--- a/docs/customize/source-files.md
+++ b/docs/customize/source-files.md
@@ -1,4 +1,4 @@
-
+(customize:source-files)=
 # Add buttons to link to your source
 
 There are a collection of buttons that you can use to link back to your source

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -1,3 +1,4 @@
+(customize:launch)=
 # Add launch buttons for interactivity
 
 You can automatically add buttons that allow users to interact with your

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -7,14 +7,16 @@ stylesheet = sphinx-book-theme.27151f2de8a6da6e72b57ec231ceb131.css
 
 [options]
 single_page = False
-expand_toc_sections = []  # DEPRECATE after a few release cycles
+# DEPRECATE after a few release cycles
+expand_toc_sections = []
 path_to_docs =
 repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-navbar_footer_text =   # DEPRECATE after a few release cycles
+# DEPRECATE after a few release cycles
+navbar_footer_text =
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
 use_issues_button = False

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -7,13 +7,14 @@ stylesheet = sphinx-book-theme.27151f2de8a6da6e72b57ec231ceb131.css
 
 [options]
 single_page = False
+expand_toc_sections = []  # DEPRECATE after a few release cycles
 path_to_docs =
 repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-navbar_footer_text =  # DEPRECATE after a few release cycles
+navbar_footer_text =   # DEPRECATE after a few release cycles
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
 use_issues_button = False

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -7,14 +7,13 @@ stylesheet = sphinx-book-theme.27151f2de8a6da6e72b57ec231ceb131.css
 
 [options]
 single_page = False
-expand_toc_sections = []
 path_to_docs =
 repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-navbar_footer_text =
+navbar_footer_text =  # DEPRECATE after a few release cycles
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
 use_issues_button = False

--- a/src/jinja/theme.conf.j2
+++ b/src/jinja/theme.conf.j2
@@ -7,14 +7,14 @@ stylesheet = {{ "src/scss/sphinx-book-theme.scss" | compiled_name }}
 
 [options]
 single_page = False
-expand_toc_sections = []
+expand_toc_sections = []  # DEPRECATE after a few release cycles
 path_to_docs =
 repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-navbar_footer_text =
+navbar_footer_text =   # DEPRECATE after a few release cycles
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
 use_issues_button = False

--- a/src/jinja/theme.conf.j2
+++ b/src/jinja/theme.conf.j2
@@ -7,14 +7,16 @@ stylesheet = {{ "src/scss/sphinx-book-theme.scss" | compiled_name }}
 
 [options]
 single_page = False
-expand_toc_sections = []  # DEPRECATE after a few release cycles
+# DEPRECATE after a few release cycles
+expand_toc_sections = []
 path_to_docs =
 repository_url =
 repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-navbar_footer_text =   # DEPRECATE after a few release cycles
+# DEPRECATE after a few release cycles
+navbar_footer_text =
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
 use_issues_button = False


### PR DESCRIPTION
Adds a reference for all the configuration options that we support. Roughly inspired from [Furo's customization landing page](https://pradyunsg.me/furo/customisation/) but laid out like a traditional table.

closes #361 