### PR TITLE
📚 DOCS: Correct wrong filename for default search field

### DIFF
--- a/docs/customize/sidebar-primary.md
+++ b/docs/customize/sidebar-primary.md
@@ -33,7 +33,7 @@ See the [Sphinx HTML sidebars documentation](https://www.sphinx-doc.org/en/maste
 
 By default, this theme comes with these three theme-specific sidebar elements enabled on all pages:
 
-- `sidebar-search-bs.html`: A bootstrap-based search bar (from the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/))
+- `search-field.html`: A bootstrap-based search bar (from the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/))
 - `sbt-sidebar-nav.html`: A bootstrap-based navigation menu for your book.
 - `sbt-sidebar-footer`: A [configurable](custom-footer) snippet of HTML to add to the sidebar (by default it is placed at the bottom).
 


### PR DESCRIPTION
I *think* this is the correct filename.  The text I replaced refers to a non-existing filename.  
If I use the updated filename I get the correct search box otherwise I get a missing template 
error while building.

closes https://github.com/executablebooks/sphinx-book-theme/issues/329