### PR TITLE
DOCS: Add note of margin CSS classes

### DIFF
--- a/docs/content-blocks.md
+++ b/docs/content-blocks.md
@@ -98,11 +98,24 @@ table of contents lives. When the reader scrolls sidebar content into view, the
 right TOC should hide itself automatically.
 ```
 
-## Margin content
+### Margin content
 
 You can specify content that should exist in the right margin. This will behave
 like a regular sidebar until the screen hits a certain width, at which point this
-content will "pop out" to the right white space. To add margin content, use this syntax:
+content will "pop out" to the right white space.
+
+There are two ways to add content to the margin: via the `{margin}` directive, and via adding CSS classes to your own content.
+
+#### Use a `{margin}` directive to add margin content
+
+The `{margin}` directive allows you to create margin content with your own title and content block.
+It is a wrapper around the Sphinx `{sidebar}` directive, and largely does its magic via CSS classes (see below).
+
+Here's how you can use the `{margin}` directive:
+
+```{margin} **Here is my margin content**
+It is pretty cool!
+```
 
 ````
 ```{margin} **My margin title**
@@ -110,27 +123,94 @@ Here is my margin content, it is pretty cool!
 ```
 ````
 
-```{margin} **Here is my margin content**
-It is pretty cool!
+#### Use CSS classes to add margin content
+
+You may also directly add CSS classes to elements on your page in order to make them behave like margin content.
+To do so, add the `margin` CSS class to any element on the page.
+Many Sphinx directives allow you to directly add classes.
+For example, here's the syntax to add a `margin` class to a `{note}` directive:
+
+:::{note}
+:class: margin
+This note will be in the margin!
+:::
+
 ```
+:::{note}
+:class: margin
+This note will be in the margin!
+:::
+```
+
+This works for most elements on the page, but in general this works best for "parent containers" that are the top-most element of a bundle of content.
+
+For example, we can even put a whole figure in the margin like so:
+
+
+You can also put the whole figure in the margin if you like.
+Here is a figure with a caption below. We'll add a note below to create
+some vertical space to see better.
+
+```{figure} images/cool.jpg
+---
+figclass: margin
+alt: My figure text
+name: myfig4
+---
+And here is my figure caption
+```
+
+````
+```{figure} images/cool.jpg
+---
+figclass: margin
+alt: My figure text
+name: myfig4
+---
+And here is my figure caption
+```
+````
+
+We can reference the figure with {ref}`myfig4`. Or a numbered reference like
+{numref}`myfig4`.
+
+#### Figure captions in the margin
+
+You can configure figures to use the margin for captions.
+Here is a figure with a caption to the right.
+
+```{figure} images/cool.jpg
+---
+width: 60%
+figclass: margin-caption
+alt: My figure text
+name: myfig5
+---
+And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-).
+```
+
+And the text that produced it:
+
+````
+```{figure} images/cool.jpg
+---
+width: 60%
+figclass: margin-caption
+alt: My figure text
+name: myfig5
+---
+And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-)
+```
+````
+
+We can reference the figure with {ref}`this reference <myfig5>`. Or a numbered reference like
+{numref}`myfig5`.
 
 ### Content sidebars
 
 Content sidebars exist in-line with your text, but allow the rest of the
 page to flow around them, rather than moving to the right margin.
 To add content sidebars, use this syntax:
-
-````
-```{sidebar} **My sidebar title**
-Here is my sidebar content, it is pretty cool!
-```
-````
-
-Note how the content wraps around the sidebar to the right.
-However, the sidebar text will still be in line with your content. There are
-certain kinds of elements, such as "note" blocks and code cells, that may
-clash with your sidebar. If this happens, try using a `{margin}` instead.
-
 
 ````{sidebar} **My sidebar title**
 ```{note}
@@ -139,6 +219,16 @@ Here is my sidebar content, it is pretty cool!
 ![](images/cool.jpg)
 ````
 
+Note how the content wraps around the sidebar to the right.
+However, the sidebar text will still be in line with your content. There are
+certain kinds of elements, such as "note" blocks and code cells, that may
+clash with your sidebar. If this happens, try using a `{margin}` instead.
+
+````
+```{sidebar} **My sidebar title**
+Here is my sidebar content, it is pretty cool!
+```
+````
 
 ### Adding content to margins and sidebars
 
@@ -175,40 +265,6 @@ Wow, a note with an image in a margin!
 ```
 ````
 `````
-
-### Margin figure captions
-
-There are a few theme-specific figure configurations. Here is a figure with
-a caption to the right.
-
-```{figure} images/cool.jpg
----
-width: 60%
-figclass: margin-caption
-alt: My figure text
-name: myfig5
----
-And here is my figure caption
-```
-
-We can reference the figure with {ref}`myfig5`. Or a numbered reference like
-{numref}`myfig5`.
-
-And here is a figure with a caption below. We'll add a note below to create
-some vertical space to see better.
-
-```{figure} images/cool.jpg
----
-figclass: margin
-alt: My figure text
-name: myfig4
----
-And here is my figure caption
-```
-
-We can reference the figure with {ref}`myfig4`. Or a numbered reference like
-{numref}`myfig4`.
-
 
 ## Full-width content
 


### PR DESCRIPTION
In a recent chat with @jacobtomlinson I realized that we don't explicitly show how classes can be used to put content in the margins. This adds that content in there!