### PR TITLE
Add support for navigation depth limit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,7 @@ html_theme_options = {
     # "extra_footer": "<a href='https://google.com'>Test</a>",  # DEPRECATED KEY
     # "extra_navbar": "<a href='https://google.com'>Test</a>",
     # "show_navbar_depth": 2,
+    # "navigation_depth": 1,  # This is a pydata config value
 }
 
 # -- ABlog config -------------------------------------------------

--- a/docs/customize/sidebar-primary.md
+++ b/docs/customize/sidebar-primary.md
@@ -98,10 +98,19 @@ html_theme_options = {
 ```
 
 (sidebar:navbar-depth)=
-## Control the depth of the left sidebar lists to expand
+## Depth of the navigation sidebar links
 
-You can control the level of toc items in the left sidebar to remain expanded,
-using the following configuration in `conf.py`:
+By default, the theme's sidebar will:
+
+- Contain links to *all* pages in your navigation
+- Collapse all nested links under their parent, except for the active page.
+
+You can modify the behavior of both of these options.
+
+### Change how many navigation levels are shown
+
+By default only the top-most navigation links are shown, except for those underneath the currently-active page.
+If you'd like nested links to be shown, you can control the level of toc items in the left sidebar to remain expanded using the following configuration in `conf.py`:
 
 ```python
 html_theme_options = {
@@ -112,3 +121,21 @@ html_theme_options = {
 ```
 
 The default value is `1`, which shows only top-level sections of the documentation (and is used in this documentation).
+
+### Change how many navigation levels are included in the sidebar
+
+Sometimes you don't want levels of your navigation included *at all*.
+This is most-useful if you have lots of nested levels (e.g., for generated API documentation) that can slow down build times considerably.
+
+To **remove** some levels from your navigation, use the following configuration in `conf.py`:
+
+```python
+html_theme_options = {
+    ...
+    "navigation_depth": <level>,
+    ...
+}
+```
+
+This will not include those levels in the navigation at all, unless users click on the
+If your documentation site is really large, or really slow to build, try experimenting with this to see if it speeds things up.

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -76,30 +76,28 @@ def update_all(app, env):
 
 
 def add_to_context(app, pagename, templatename, context, doctree):
-
-    # TODO: remove this whenever the nav collapsing functionality is in the PST
     def sbt_generate_nav_html(
-        level=1,
-        include_item_names=False,
         with_home_page=False,
-        prev_section_numbers=None,
         show_depth=1,
+        maxdepth=None,
     ):
+        """
+        with_home_page: include the home page as the top link in the toc
+        show_depth: how many layers of the TOC should be shown by default
+        maxdepth: how mnay layers of the TOC should be included in the toctree at all
+        """
         # Config stuff
         config = app.env.config
-        if isinstance(with_home_page, str):
-            with_home_page = with_home_page.lower() == "true"
 
         # Convert the pydata toctree html to beautifulsoup
         toctree = context["generate_nav_html"](
-            startdepth=level - 1,
+            startdepth=0,
             kind="sidebar",
-            maxdepth=4,
+            maxdepth=maxdepth,
             collapse=False,
             includehidden=True,
             titles_only=True,
         )
-        toctree = bs(toctree, "html.parser")
 
         # Add the master_doc page as the first item if specified
         if with_home_page:
@@ -115,18 +113,17 @@ def add_to_context(app, pagename, templatename, context, doctree):
             if context["pagename"] == master_doc:
                 li_class += " current"
             # Insert it into our toctree
-            ul_home = bs(
-                f"""
+            title_element = f"""
             <ul class="nav bd-sidenav">
                 <li class="{li_class}">
                     <a href="{master_url}" class="reference internal">{master_title}</a>
                 </li>
-            </ul>""",
-                "html.parser",
-            )
-            toctree.insert(0, ul_home("ul")[0])
+            </ul>
+            """
+            toctree = f"{title_element}\n{toctree}"
 
         # Open the navbar to the proper depth
+        toctree = bs(toctree, "html.parser")
         for ii in range(int(show_depth)):
             for checkbox in toctree.select(
                 f"li.toctree-l{ii} > input.toctree-checkbox"

--- a/sphinx_book_theme/_templates/sbt-sidebar-nav.html
+++ b/sphinx_book_theme/_templates/sbt-sidebar-nav.html
@@ -1,5 +1,9 @@
 <nav class="bd-links" id="bd-docs-nav" aria-label="Main">
     <div class="bd-toc-item active">
-        {{ sbt_generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc, show_depth=theme_show_navbar_depth) }}
+        {{ sbt_generate_nav_html(
+            with_home_page=theme_home_page_in_toc|tobool,
+            show_depth=theme_show_navbar_depth|int,
+            maxdepth=theme_navigation_depth|int)
+        }}
     </div>
 </nav>


### PR DESCRIPTION
This PR adds functionality for the `navigation_depth` parameter from the PyData Sphinx Theme - this will remove all toctree items underneath a certain depth, which can significantly speed up the build times.

This is largely sparked by some challenges that the Dask devs ran into with this theme, but I think it will be common with any community that uses this theme and has a lot of API docs. Here's the Dask issue in question:

https://github.com/dask/dask/issues/8227