### PR TITLE
DOCS: Note TOC level auto-show

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,7 @@ html_theme_options = {
     # "extra_footer": "<a href='https://google.com'>Test</a>",  # DEPRECATED KEY
     # "extra_navbar": "<a href='https://google.com'>Test</a>",
     # "show_navbar_depth": 2,
+    "show_toc_level": 2,
 }
 
 # -- ABlog config -------------------------------------------------

--- a/docs/customize/sidebar-secondary.md
+++ b/docs/customize/sidebar-secondary.md
@@ -15,3 +15,17 @@ html_theme_options = {
 ```
 
 The default value of the title is `Contents`.
+
+## Show more levels of the in-page TOC by default
+
+Normally only the 2nd-level headers of a page are shown in the within-page table of contents, and deeper levels are only shown when they are part of an active section (when it is scrolled on screen).
+
+You can show deeper levels by default by using the following configuration, indicating how many levels should be displayed:
+
+```python
+html_theme_options = {
+  "show_toc_level": 2
+}
+```
+
+All headings up to and including the level specified will now be shown regardless of what is displayed on the page.


### PR DESCRIPTION
This documents a feature to configure the in-page TOC to automatically show - it is brought in from the pydata theme.