### PR TITLE
UPDATE: pydata-sphinx-theme 0.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "click~=7.1",
         "docutils>=0.15,<0.17",
         'importlib-resources>=3.0,<3.5; python_version < "3.7"',
-        "pydata-sphinx-theme~=0.7.1",
+        "pydata-sphinx-theme~=0.7.2",
         "pyyaml",
         "sphinx>=3,<5",
     ],


### PR DESCRIPTION
Fixes https://github.com/executablebooks/sphinx-book-theme/issues/427. and fixes https://github.com/executablebooks/sphinx-book-theme/issues/423 Or..it should..~~but I'm not sure because https://github.com/executablebooks/sphinx-book-theme/issues/428 makes me think what's in this repo is not making it out to pypi.~~ **edit** it hasn't, and that's expected: https://github.com/executablebooks/sphinx-book-theme/issues/428#issuecomment-966021270. And this should be unnecessary since the new version is already pinned to `~=0.7.1` which covers 0.7.2 as well.