### PR TITLE
MAINT: Add Python 3.9 to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - uses: pre-commit/action@v2.0.0
 
   tests:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         sphinx: [">=3,<4", ">=4,<5"]
         include:
         - os: windows-latest

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,14 @@ envlist = py37-sphinx3
 [testenv]
 usedevelop=true
 
-[testenv:py{36,37,38}-sphinx{3,4}]
+[testenv:py{36,37,38,39}-sphinx{3,4}]
 extras = testing
 deps =
     sphinx3: sphinx>=3,<4
     sphinx4: sphinx>=4,<5
 commands = pytest {posargs}
 
-[testenv:py{36,37,38}-pre-commit]
+[testenv:py{36,37,38,39}-pre-commit]
 extras = code_style
 commands = pre-commit run {posargs}
 


### PR DESCRIPTION
This adds Python 3.9 to our tox file as well as our github action tests.