### PR TITLE
FIX: Tooltip hover remain bug

### DIFF
--- a/src/sphinx_book_theme/assets/scripts/index.js
+++ b/src/sphinx_book_theme/assets/scripts/index.js
@@ -58,7 +58,7 @@ var toggleFullScreen = () => {
 // Enable tooltips
 var initTooltips = () => {
   $(document).ready(function () {
-    $('[data-toggle="tooltip"]').tooltip();
+    $('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
   });
 };
 


### PR DESCRIPTION
The issue here was that the bootstrap tooltip was watching for `hover focus`, and if you clickk, you give the button focus, so that's why it was remaining. Ref: https://stackoverflow.com/questions/33584392/bootstraps-tooltip-doesnt-disappear-after-button-click-mouseleave

closes https://github.com/executablebooks/sphinx-book-theme/issues/407