### PR TITLE
MAINT: Fix translation asset generation

### DIFF
--- a/src/sphinx_book_theme/_compile_translations.py
+++ b/src/sphinx_book_theme/_compile_translations.py
@@ -1,3 +1,4 @@
+"""Generate compiled static translation assets for Sphinx."""
 import json
 import os
 from pathlib import Path
@@ -10,11 +11,11 @@ RENAME_LANGUAGE_CODES = {
 }
 
 
-def convert_json(folder=None):
-    folder = folder or Path(__file__).parent / "assets" / "translations"
-    out_folder = (
-        folder or Path(__file__).parent / "theme" / "sphinx_book_theme" / "static"
-    )
+def convert_json():
+    # Raw translation JSONs that are hand-edited
+    folder = Path(__file__).parent / "assets" / "translations"
+    # Location of compiled static translation assets
+    out_folder = Path(__file__).parent / "theme" / "sphinx_book_theme" / "static"
 
     # compile po
     for path in (folder / "jsons").glob("*.json"):

--- a/src/sphinx_book_theme/assets/translations/.gitignore
+++ b/src/sphinx_book_theme/assets/translations/.gitignore
@@ -1,1 +1,0 @@
-locales


### PR DESCRIPTION
This fixes a minor bug that was causing our translation static assets to land in the wrong spot.

Going to merge this because our compile step is broken without it!