### PR TITLE
DOCS: Add reference page for numpydocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ master_doc = "index"
 extensions = [
     "ablog",
     "myst_nb",
+    "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ reference/extensions
 reference/notebooks
 reference/thebe
 reference/blog
+reference/api-numpy
 ```
 
 # Inspiration

--- a/docs/reference/api-numpy.md
+++ b/docs/reference/api-numpy.md
@@ -1,0 +1,11 @@
+# NumPy docstrings
+
+This page demonstrates NumPy docstrings for the theme, as well as some other common Sphinx directives for API documentation.
+
+```{versionadded} 0.1.1
+```
+
+```{eval-rst}
+.. automodule:: numpy
+   :members: array, transpose
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ doc = [
     "folium",
     "numpy",
     "matplotlib",
+    "numpydoc",
     "myst-nb~=0.13",
     "nbclient",
     "pandas",


### PR DESCRIPTION
This adds a reference page for numpy-style docstrings, to have a way to make sure the styles etc still behave as expected. We shouldn't need to change any styles because these docstrings are already supported now via the pydata theme.

closes #266 