### PR TITLE
MAINT: Add dependabot config

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot configuration
+# ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds [github's dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) to the repository, to automatically open up PRs when dependencies of jupyter book are updated. This should reduce the amount of toil associated with noticing when dependencies are updated, and bumping versions when they are. Since our tests are automatically run with PRs, we should then be able to merge quickly if tests are passing and there don't seem to be any breaking changes.

I don't believe anything this will happen until we merge this, so I'll merge it in and we can test it out in this repository to see if / how it works.