### PR TITLE
FIX: Double imports for CSS and hashing simplification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
     # - yahoo.com: Kitchen sink redirect we don't control
     # - someurl: dummy url
     # - mailto: fails test but works for people
+    # - pathto(: because the pydata theme packages invalid HTML w/ this in it
     - name: Check for broken links
       id: lychee
       uses: lycheeverse/lychee-action@v1.3.0
@@ -108,6 +109,7 @@ jobs:
           --exclude 'yahoo.com'
           --exclude 'someurl'
           --exclude 'mailto:docutils-develop'
+          --exclude 'pathto\('
 
     - name: Audit with Lighthouse
       uses: treosh/lighthouse-ci-action@9.3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,8 +94,6 @@ jobs:
     # - yahoo.com: Kitchen sink redirect we don't control
     # - someurl: dummy url
     # - mailto: fails test but works for people
-    # - pathto: accidental includes in our `_static` dir
-    #   HACK, ref: https://github.com/pradyunsg/sphinx-theme-builder/issues/18
     - name: Check for broken links
       id: lychee
       uses: lycheeverse/lychee-action@v1.3.0
@@ -110,8 +108,6 @@ jobs:
           --exclude 'yahoo.com'
           --exclude 'someurl'
           --exclude 'mailto:docutils-develop'
-          --exclude 'pathto\('
-          --exclude 'deepnote.com'
 
     - name: Audit with Lighthouse
       uses: treosh/lighthouse-ci-action@9.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "sphinx_theme_builder"
 node-version = "16.13.2"
 theme-name = "sphinx_book_theme"
 additional-compiled-static-assets = [
-  "sbt-webpack-macros.html",
   "locales/"
 ]
 

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -1,6 +1,8 @@
 """A lightweight book theme based on the pydata sphinx theme."""
+import hashlib
 import os
 from pathlib import Path
+from functools import lru_cache
 
 from docutils.parsers.rst.directives.body import Sidebar
 from docutils import nodes
@@ -59,6 +61,36 @@ def add_metadata_to_page(app, pagename, templatename, context, doctree):
     )
 
 
+@lru_cache(maxsize=None)
+def _gen_hash(path: str) -> str:
+    """Generate a hash for an asset, where `path` is relative to theme static folder."""
+    path_asset = get_html_theme_path() / "static" / Path(path)
+    return hashlib.sha1(path_asset.read_bytes()).hexdigest()
+
+
+def add_hashes_to_assets(app, pagename, templatename, context, doctree):
+    """Add ?digest={hash} to assets in order to bust cache when changes are made."""
+    # Hash the CSS
+    css_to_hash = ["styles/sphinx-book-theme.css"]
+    if "css_files" in context:
+        css_files = context["css_files"]
+        for css_file in css_to_hash:
+            # Source folder is named `static`, built HTML is in `_static`
+            css_html_path = f"_static/{css_file}"
+            ix = css_files.index(css_html_path)
+            css_files[ix] = css_html_path + f"?digest={_gen_hash(css_file)}"
+
+    # Hash the JS
+    js_to_hash = ["scripts/sphinx-book-theme.js"]
+    if "script_files" in context:
+        js_files = context["script_files"]
+        for js_file in js_to_hash:
+            # Source folder is named `static`, built HTML is in `_static`
+            js_html_path = f"_static/{js_file}"
+            ix = js_files.index(js_html_path)
+            js_files[ix] = js_html_path + f"?digest={_gen_hash(js_file)}"
+
+
 def update_thebe_config(app):
     """Update thebe configuration with SBT-specific values"""
     theme_options = app.env.config.html_theme_options
@@ -113,15 +145,19 @@ class Margin(Sidebar):
 
 
 def setup(app: Sphinx):
-    app.connect("builder-inited", update_thebe_config)
-
-    # add translations
+    # Register theme
     theme_dir = get_html_theme_path()
+    app.add_html_theme("sphinx_book_theme", theme_dir)
+    app.add_js_file("scripts/sphinx-book-theme.js")
+
+    # Translations
     locale_dir = os.path.join(theme_dir, "static", "locales")
     app.add_message_catalog(MESSAGE_CATALOG_NAME, locale_dir)
 
-    app.add_html_theme("sphinx_book_theme", theme_dir)
+    # Events
+    app.connect("builder-inited", update_thebe_config)
     app.connect("html-page-context", add_metadata_to_page)
+    app.connect("html-page-context", add_hashes_to_assets)
 
     # Header buttons
     app.connect("html-page-context", prep_header_buttons)
@@ -129,6 +165,7 @@ def setup(app: Sphinx):
     # Bump priority by 1 so that it runs after the pydata theme sets up the edit URL.
     app.connect("html-page-context", add_header_buttons, priority=501)
 
+    # Directives
     app.add_directive("margin", Margin)
 
     # Update templates for sidebar

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -63,32 +63,30 @@ def add_metadata_to_page(app, pagename, templatename, context, doctree):
 
 @lru_cache(maxsize=None)
 def _gen_hash(path: str) -> str:
-    """Generate a hash for an asset, where `path` is relative to theme static folder."""
     path_asset = get_html_theme_path() / "static" / Path(path)
-    return hashlib.sha1(path_asset.read_bytes()).hexdigest()
+    return "?digest=" + hashlib.sha1(path_asset.read_bytes()).hexdigest()
 
 
 def add_hashes_to_assets(app, pagename, templatename, context, doctree):
-    """Add ?digest={hash} to assets in order to bust cache when changes are made."""
+    """Add ?digest={hash} to assets in order to bust cache when changes are made.
+
+    The source files are in `static` while the built HTML is in `_static`.
+    """
     # Hash the CSS
     css_to_hash = ["styles/sphinx-book-theme.css"]
     if "css_files" in context:
-        css_files = context["css_files"]
         for css_file in css_to_hash:
-            # Source folder is named `static`, built HTML is in `_static`
             css_html_path = f"_static/{css_file}"
-            ix = css_files.index(css_html_path)
-            css_files[ix] = css_html_path + f"?digest={_gen_hash(css_file)}"
+            ix = context["css_files"].index(css_html_path)
+            context["css_files"][ix] = css_html_path + _gen_hash(css_file)
 
     # Hash the JS
     js_to_hash = ["scripts/sphinx-book-theme.js"]
     if "script_files" in context:
-        js_files = context["script_files"]
         for js_file in js_to_hash:
-            # Source folder is named `static`, built HTML is in `_static`
             js_html_path = f"_static/{js_file}"
-            ix = js_files.index(js_html_path)
-            js_files[ix] = js_html_path + f"?digest={_gen_hash(js_file)}"
+            ix = context["script_files"].index(js_html_path)
+            context["script_files"][ix] = js_html_path + _gen_hash(js_file)
 
 
 def update_thebe_config(app):

--- a/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
+++ b/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
@@ -13,8 +13,10 @@ $grey--medium: #aaa;
 $grey--light: #ccc;
 $non-content-grey: $grey--dark;
 
-// Z-index stacking
-$zindex-overlay: 1100;
+// Z-index stacking (from Bootstrap)
+// ref: https://getbootstrap.com/docs/5.0/layout/z-index/
+$zindex-sticky: 1020;
+$zindex-offcanvas: 1050;
 
 // Spacing
 $header-article-height: 3em;

--- a/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
+++ b/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
@@ -13,6 +13,10 @@ $grey--medium: #aaa;
 $grey--light: #ccc;
 $non-content-grey: $grey--dark;
 
+// Z-index stacking
+$zindex-overlay: 1100;
+
+// Spacing
 $header-article-height: 3em;
 $leftbar-width-mobile: 75%;
 $leftbar-width-wide: 275px;

--- a/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
+++ b/src/sphinx_book_theme/assets/styles/abstracts/_variables.scss
@@ -16,7 +16,7 @@ $non-content-grey: $grey--dark;
 // Z-index stacking (from Bootstrap)
 // ref: https://getbootstrap.com/docs/5.0/layout/z-index/
 $zindex-sticky: 1020;
-$zindex-offcanvas: 1050;
+$zindex-offcanvas: 1100; // We increase this to be over the tooltips
 
 // Spacing
 $header-article-height: 3em;

--- a/src/sphinx_book_theme/assets/styles/base/_typography.scss
+++ b/src/sphinx_book_theme/assets/styles/base/_typography.scss
@@ -3,57 +3,54 @@
 *********************************************/
 
 .content-container {
-  #main-content,
-  #print-main-content {
-    // Content links and link color
-    a.headerlink {
-      opacity: 0;
-      margin-left: 0.2em;
+  // Content links and link color
+  a.headerlink {
+    opacity: 0;
+    margin-left: 0.2em;
 
-      &:hover {
-        background-color: transparent;
-        color: rgba(var(--pst-color-link), 1);
-        opacity: 1 !important;
-      }
-    }
-
-    a,
-    a:visited {
+    &:hover {
+      background-color: transparent;
       color: rgba(var(--pst-color-link), 1);
+      opacity: 1 !important;
     }
+  }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5 {
-      color: black;
-      &:hover a.headerlink {
-        opacity: 0.5;
-      }
-      // Make sure titles don't become hyperlink color when there are labels
-      a.toc-backref {
-        color: inherit;
-      }
-    }
+  a,
+  a:visited {
+    color: rgba(var(--pst-color-link), 1);
+  }
 
-    // Lists
-    ul,
-    ol {
-      p {
-        margin-bottom: 0;
-      }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    color: black;
+    &:hover a.headerlink {
+      opacity: 0.5;
     }
+    // Make sure titles don't become hyperlink color when there are labels
+    a.toc-backref {
+      color: inherit;
+    }
+  }
 
-    // Misc text and directives
-    p.centered {
-      text-align: center;
+  // Lists
+  ul,
+  ol {
+    p {
+      margin-bottom: 0;
     }
+  }
 
-    // Footnotes and Citations
-    .footnote-reference,
-    a.bibtex.internal {
-      font-size: 1em;
-    }
+  // Misc text and directives
+  p.centered {
+    text-align: center;
+  }
+
+  // Footnotes and Citations
+  .footnote-reference,
+  a.bibtex.internal {
+    font-size: 1em;
   }
 }

--- a/src/sphinx_book_theme/assets/styles/base/_typography.scss
+++ b/src/sphinx_book_theme/assets/styles/base/_typography.scss
@@ -45,25 +45,6 @@
       }
     }
 
-    // Math and equations
-    span.eqno {
-      position: absolute;
-      right: 1em;
-      top: 50%;
-      transform: translate(0, -50%);
-      font-size: 1.2em;
-    }
-
-    div.math {
-      overflow-x: auto;
-      position: relative;
-    }
-
-    // Compensate for the extra bottom margin of a preceding paragraph
-    p ~ div.math {
-      margin-top: -1.15rem;
-    }
-
     // Misc text and directives
     p.centered {
       text-align: center;

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -92,7 +92,8 @@
 div.header-article-main {
   .menu-dropdown__content {
     a,
-    button {
+    button,
+    label {
       color: $non-content-grey;
       padding: 0;
 

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -86,7 +86,7 @@
 
   a,
   button {
-    color: $non-content-grey;
+    color: $non-content-grey !important; // HACK: over-ride too-specific PST CSS
     padding: 0;
   }
 

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -86,19 +86,20 @@
 
   a,
   button {
+    color: $non-content-grey;
     padding: 0;
   }
 
   span {
     display: flex;
-  }
 
-  span.headerbtn__icon-container {
-    width: 2em;
-  }
+    &.headerbtn__icon-container {
+      width: 2em;
+    }
 
-  span.headerbtn__text-container {
-    flex-grow: 1;
+    &.headerbtn__text-container {
+      flex-grow: 1;
+    }
   }
 }
 

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -20,7 +20,7 @@
   // Over-ride bootstrap defaults for clicking
   &:hover,
   &:focus {
-    color: black;
+    color: black !important;
     background-color: white;
     box-shadow: none;
     text-decoration: none;
@@ -84,12 +84,6 @@
     margin-bottom: 0;
   }
 
-  a,
-  button {
-    color: $non-content-grey !important; // HACK: over-ride too-specific PST CSS
-    padding: 0;
-  }
-
   span {
     display: flex;
 
@@ -99,6 +93,17 @@
 
     &.headerbtn__text-container {
       flex-grow: 1;
+    }
+  }
+}
+
+// HACK: Need this to be extra-selective to over-ride some too-specific PST CSS
+div.header-article-main {
+  .menu-dropdown__content {
+    a,
+    button {
+      color: $non-content-grey;
+      padding: 0;
     }
   }
 }

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -56,7 +56,6 @@
 
   // Spacing and position
   width: 13em;
-  z-index: 1000;
   border-radius: $box-border-radius;
   box-shadow: 0px 3px 10px 0px rgba(0, 0, 0, 0.25);
   padding: 0.5em;

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -57,6 +57,7 @@
 
   .headerbtn {
     justify-content: left;
+    padding: 0.1rem 0rem;
 
     // Center the icon in the available white space
     i,

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -17,15 +17,6 @@
   padding: 0.1rem 0.5rem; // Horizontal padding since labels have none
   margin: 0 0.1rem;
 
-  // Over-ride bootstrap defaults for clicking
-  &:hover,
-  &:focus {
-    color: black !important;
-    background-color: white;
-    box-shadow: none;
-    text-decoration: none;
-  }
-
   span {
     display: flex;
     align-items: center;
@@ -104,6 +95,14 @@ div.header-article-main {
     button {
       color: $non-content-grey;
       padding: 0;
+
+      // Over-ride bootstrap defaults for clicking
+      &:hover,
+      &:focus {
+        color: black;
+        box-shadow: none;
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -90,12 +90,12 @@
 
 // HACK: Need this to be extra-selective to over-ride some too-specific PST CSS
 div.header-article-main {
-  .menu-dropdown__content {
+  .header-article__left,
+  .header-article__right {
     a,
     button,
     label {
       color: $non-content-grey;
-      padding: 0;
 
       // Over-ride bootstrap defaults for clicking
       &:hover,

--- a/src/sphinx_book_theme/assets/styles/content/_math.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_math.scss
@@ -4,32 +4,31 @@ div.math {
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
+
+  .headerlink {
+    font-size: 1em;
+    padding: 0 0.2em;
+    margin-left: 0;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  &:hover .headerlink {
+    opacity: 0.5;
+  }
 }
 
 // Equation labels to the right
 span.eqno {
   font-size: 1.2em;
   margin-left: 0.5em;
-
-  .headerlink {
-    font-size: 1em;
-    padding: 0 0 0 0.2em;
-    margin-left: 0 !important; // HACK: Overly-specific CSS rule
-    visibility: visible;
-  }
-
-  &:hover .headerlink {
-    opacity: 0.5 !important; // HACK: over-ride an overly-specific rule
-  }
-
-  .headerlink:hover {
-    opacity: 1;
-  }
 }
 
 .MathJax {
   overflow-x: auto;
-  margin-right: auto !important; // to over-ride MathJax default behavior
+  margin-right: auto !important; // HACK: to over-ride MathJax default behavior
   margin-left: auto !important;
   @include scrollbar-style();
 }

--- a/src/sphinx_book_theme/assets/styles/content/_math.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_math.scss
@@ -1,15 +1,35 @@
 // Math and equations
-span.eqno {
-  position: absolute;
-  right: 1em;
-  top: 50%;
-  transform: translate(0, -50%);
-  font-size: 1.2em;
+div.math {
+  position: relative;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: center;
 }
 
-div.math {
+// Equation labels to the right
+span.eqno {
+  font-size: 1.2em;
+  margin-left: 0.5em;
+
+  .headerlink {
+    font-size: 1em;
+    padding: 0 0 0 0.2em;
+    margin-left: 0 !important; // HACK: Overly-specific CSS rule
+    visibility: visible;
+  }
+
+  &:hover .headerlink {
+    opacity: 0.5 !important; // HACK: over-ride an overly-specific rule
+  }
+
+  .headerlink:hover {
+    opacity: 1;
+  }
+}
+
+.MathJax {
   overflow-x: auto;
-  position: relative;
   @include scrollbar-style();
 }
 

--- a/src/sphinx_book_theme/assets/styles/content/_math.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_math.scss
@@ -4,7 +4,6 @@ div.math {
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
-  justify-content: center;
 }
 
 // Equation labels to the right
@@ -30,6 +29,8 @@ span.eqno {
 
 .MathJax {
   overflow-x: auto;
+  margin-right: auto !important; // to over-ride MathJax default behavior
+  margin-left: auto !important;
   @include scrollbar-style();
 }
 

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -11,7 +11,6 @@
   border-right: $border-thin;
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
-  z-index: 2000 !important;
 
   @include scrollbar-style();
   @include scrollbar-on-hover();
@@ -21,6 +20,7 @@
     width: $leftbar-width-mobile;
     max-width: 300px;
     font-size: 1.2em;
+    z-index: $zindex-overlay;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -20,7 +20,7 @@
     width: $leftbar-width-mobile;
     max-width: 300px;
     font-size: 1.2em;
-    z-index: $zindex-overlay;
+    z-index: $zindex-offcanvas;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -5,7 +5,6 @@
 .bd-toc {
   padding: 0px !important;
   right: -1em;
-  z-index: 999;
   height: auto;
   transition: margin-right $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
@@ -18,6 +17,7 @@
 
   // On narrow screens, this should be offset to the right side until button is clicked
   @media (max-width: $breakpoint-md) {
+    z-index: $zindex-overlay;
     top: 0;
     right: 0;
     position: fixed;

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -17,7 +17,7 @@
 
   // On narrow screens, this should be offset to the right side until button is clicked
   @media (max-width: $breakpoint-md) {
-    z-index: $zindex-overlay;
+    z-index: $zindex-offcanvas;
     top: 0;
     right: 0;
     position: fixed;

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
@@ -63,11 +63,11 @@ label.overlay {
 @media (max-width: $breakpoint-md) {
   input:checked + label.overlay {
     &.overlay-navbar {
-      z-index: 1040; // This puts it above the header, below the sidebar
+      z-index: $zindex-overlay - 1; // This puts it just below the primary sidebar
     }
 
     &.overlay-pagetoc {
-      z-index: 1010; // This puts it *below* the header so the TOC shows
+      z-index: $zindex-overlay - 1; // This puts it just below the secondary sidebar
     }
     height: 100%;
     opacity: 1;

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
@@ -63,11 +63,11 @@ label.overlay {
 @media (max-width: $breakpoint-md) {
   input:checked + label.overlay {
     &.overlay-navbar {
-      z-index: $zindex-overlay - 1; // This puts it just below the primary sidebar
+      z-index: $zindex-offcanvas - 1; // This puts it just below the primary sidebar
     }
 
     &.overlay-pagetoc {
-      z-index: $zindex-overlay - 1; // This puts it just below the secondary sidebar
+      z-index: $zindex-sticky - 1; // This puts it just below the header
     }
     height: 100%;
     opacity: 1;

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -98,10 +98,10 @@ def add_launch_buttons(
     launch_buttons_list = []
 
     # Now build infrastructure-specific links
-    jupyterhub_url = launch_buttons.get("jupyterhub_url")
-    binderhub_url = launch_buttons.get("binderhub_url")
-    colab_url = launch_buttons.get("colab_url")
-    deepnote_url = launch_buttons.get("deepnote_url")
+    jupyterhub_url = launch_buttons.get("jupyterhub_url", "").strip("/")
+    binderhub_url = launch_buttons.get("binderhub_url", "").strip("/")
+    colab_url = launch_buttons.get("colab_url", "").strip("/")
+    deepnote_url = launch_buttons.get("deepnote_url", "").strip("/")
     if binderhub_url:
         url = (
             f"{binderhub_url}/v2/gh/{org}/{repo}/{branch}?"

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -1,11 +1,5 @@
 {% extends "pydata_sphinx_theme/layout.html" %}
-{% import "static/sbt-webpack-macros.html" as _sbtwebpack with context %}
 {# ref: https://github.com/pydata/pydata-sphinx-theme/blob/master/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html #}
-
-{%- block css %}
-    {{ super() }}
-    {{ _sbtwebpack.head_pre_bootstrap() }}
-{%- endblock %}
 
 {% set is_single_page = (theme_single_page == True) or (theme_single_page == "True") %}
 
@@ -86,11 +80,6 @@
     {% endblock %}
 </div>
 {% endblock %}
-
-{%- block scripts_end %}
-  {{ super() }}
-  {{ _sbtwebpack.body_post() }}
-{%- endblock %}
 
 {% block docs_toc %}
 {% endblock %}

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/static/.gitignore
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/static/.gitignore
@@ -1,4 +1,3 @@
 styles
 scripts
 locales
-sbt-webpack-macros.html

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/static/sbt-webpack-macros.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/static/sbt-webpack-macros.html
@@ -1,0 +1,11 @@
+<!--
+  All these macros are auto-generated and must **NOT** be edited by hand.
+  See the webpack.config.js file, to learn more about how this is generated.
+-->
+{% macro head_pre_bootstrap() %}
+  <link href="{{ pathto('_static/styles/sphinx-book-theme.css', 1) }}" rel="stylesheet">
+{% endmacro %}
+
+{% macro body_post() %}
+  <script src="{{ pathto('_static/scripts/sphinx-book-theme.js', 1) }}"></script>
+{% endmacro %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,16 +19,15 @@ const staticPath = resolve(
 // Cache-busting Jinja2 macros (`webpack-macros.html`) used in `layout.html`
 //
 function macroTemplate({ compilation }) {
-  const hash = compilation.hash;
   const css_files = ["styles/sphinx-book-theme.css"];
   const js_files = ["scripts/sphinx-book-theme.js"];
 
   function stylesheet(css) {
-    return `<link href="{{ pathto('_static/${css}', 1) }}?digest=${hash}" rel="stylesheet">`;
+    return `<link href="{{ pathto('_static/${css}', 1) }}" rel="stylesheet">`;
   }
 
   function script(js) {
-    return `<script src="{{ pathto('_static/${js}', 1) }}?digest=${hash}"></script>`;
+    return `<script src="{{ pathto('_static/${js}', 1) }}"></script>`;
   }
   return dedent(`\
     <!--

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 // Webpack configuration for sphinx-book-theme
 const { resolve } = require("path");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const dedent = require("dedent");
@@ -14,35 +13,6 @@ const staticPath = resolve(
   __dirname,
   "src/sphinx_book_theme/theme/sphinx_book_theme/static"
 );
-
-//
-// Cache-busting Jinja2 macros (`webpack-macros.html`) used in `layout.html`
-//
-function macroTemplate({ compilation }) {
-  const css_files = ["styles/sphinx-book-theme.css"];
-  const js_files = ["scripts/sphinx-book-theme.js"];
-
-  function stylesheet(css) {
-    return `<link href="{{ pathto('_static/${css}', 1) }}" rel="stylesheet">`;
-  }
-
-  function script(js) {
-    return `<script src="{{ pathto('_static/${js}', 1) }}"></script>`;
-  }
-  return dedent(`\
-    <!--
-      All these macros are auto-generated and must **NOT** be edited by hand.
-      See the webpack.config.js file, to learn more about how this is generated.
-    -->
-    {% macro head_pre_bootstrap() %}
-      ${css_files.map(stylesheet).join("\n  ")}
-    {% endmacro %}
-
-    {% macro body_post() %}
-      ${js_files.map(script).join("\n  ")}
-    {% endmacro %}
-  `);
-}
 
 module.exports = {
   mode: "production",
@@ -86,13 +56,4 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new HtmlWebpackPlugin({
-      filename: resolve(staticPath, "sbt-webpack-macros.html"),
-      inject: false,
-      minify: false,
-      css: true,
-      templateContent: macroTemplate,
-    }),
-  ],
 };


### PR DESCRIPTION
This PR does two things:

- Generates hashes for CSS and JS inside of Python rather than with webpack. This means we don't need to generate HTML macros with our assets, which means we don't need to package these HTML macro snippets with our site HTML
- It also means we no longer duplicate CSS in our outputs, which closes #496 

While testing that this worked, I also fixed two CSS bugs:

- Removed most of the z-index uses because they weren't necessary anymore - we now only use z-index for the sidebar overlays on mobile. closes https://github.com/executablebooks/sphinx-book-theme/issues/180
- Fixed the equation label overlapping with the equation (and not having an anchor that you could click). closes https://github.com/executablebooks/sphinx-book-theme/issues/176

### To Do

- [x] Make sure button colors are correct (they were blue in a previous iteration)