### PR TITLE
STYLE: Slightly smaller margins for lower headers

### DIFF
--- a/src/sphinx_book_theme/assets/styles/base/_typography.scss
+++ b/src/sphinx_book_theme/assets/styles/base/_typography.scss
@@ -35,6 +35,14 @@
     }
   }
 
+  // Over-rides the pydata theme's large margins
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 1em;
+  }
+
   // Lists
   ul,
   ol {


### PR DESCRIPTION
This lowers the top margins for h3+ headers, so there's less whitespace for successive sections.