### PR TITLE
MAINT: Pin our github actions to minor versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-python@v2.3.2
+    - uses: actions/checkout@v2.4
+    - uses: actions/setup-python@v2.3
       with:
         python-version: 3.9
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v2.0
 
   tests:
     strategy:
@@ -52,7 +52,7 @@ jobs:
 
     - name: Upload to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && github.repository == 'executablebooks/sphinx-book-theme'
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v2.1
       with:
         name: ebp-sbt-pytests-py3.7
         flags: pytests
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Audit Documentation
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2.4
     - name: Set up Python
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2.3
       with:
         python-version: '3.7'
         cache: "pip"
@@ -97,7 +97,7 @@ jobs:
     # - pathto(: because the pydata theme packages invalid HTML w/ this in it
     - name: Check for broken links
       id: lychee
-      uses: lycheeverse/lychee-action@v1.3.1
+      uses: lycheeverse/lychee-action@v1.3
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
@@ -112,7 +112,7 @@ jobs:
           --exclude 'pathto\('
 
     - name: Audit with Lighthouse
-      uses: treosh/lighthouse-ci-action@9.3.0
+      uses: treosh/lighthouse-ci-action@9.3
       with:
         configPath: ".github/workflows/lighthouserc.json"
         temporaryPublicStorage: true
@@ -127,9 +127,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2.4
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2.3.2
+        uses: actions/setup-python@v2.3
         with:
           python-version: 3.7
 
@@ -139,7 +139,7 @@ jobs:
           python -m build
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.5
         with:
           user: __token__
           password: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
This pins our github actions to minor versions, rather than patch versions, simulating the `~=` syntax we follow for Python dependencies.