### PR TITLE
FIX: Always use dropdown with launch buttons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ html_theme_options = {
     # "repository_branch": "gh-pages",  # For testing
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
-        # "jupyterhub_url": "https://datahub.berkeley.edu",  # For testing
+        "jupyterhub_url": "https://datahub.berkeley.edu",  # For testing
         "colab_url": "https://colab.research.google.com/",
         "deepnote_url": "https://deepnote.com/",
         "notebook_interface": "jupyterlab",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,11 +108,11 @@ html_theme_options = {
     # "repository_branch": "gh-pages",  # For testing
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
-        "jupyterhub_url": "https://datahub.berkeley.edu",  # For testing
         "colab_url": "https://colab.research.google.com/",
         "deepnote_url": "https://deepnote.com/",
         "notebook_interface": "jupyterlab",
         "thebe": True,
+        # "jupyterhub_url": "https://datahub.berkeley.edu",  # For testing
     },
     "use_edit_page_button": True,
     "use_issues_button": True,

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -22,9 +22,12 @@
     align-items: center;
   }
 
+  // Icons and image icons
   img,
   i {
     margin: auto;
+    width: 1em;
+    text-align: center;
   }
 }
 
@@ -59,14 +62,9 @@
     justify-content: left;
     padding: 0.1rem 0rem;
 
-    // Center the icon in the available white space
-    i,
-    img {
-      margin: auto;
-    }
-
-    img {
-      width: 1em;
+    img,
+    i {
+      font-size: 0.9em;
     }
   }
 

--- a/src/sphinx_book_theme/header_buttons/__init__.py
+++ b/src/sphinx_book_theme/header_buttons/__init__.py
@@ -124,7 +124,9 @@ def add_header_buttons(app, pagename, templatename, context, doctree):
                     "label": "repository-buttons",
                 }
             )
-        else:
+        elif len(repo_buttons) == 1:
+            # Remove the text since it's just a single button, want just an icon.
+            repo_buttons[0]["text"] = ""
             header_buttons.extend(repo_buttons)
 
     # Download buttons for various source content.

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -173,6 +173,8 @@ def add_launch_buttons(
 
     # Add the buttons to header_buttons
     if len(launch_buttons_list) == 1:
+        # Remove the text since it's just a single button, want just an icon.
+        launch_buttons_list[0]["text"] = ""
         header_buttons.extend(launch_buttons_list)
     else:
         for lb in launch_buttons_list:

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -172,22 +172,17 @@ def add_launch_buttons(
         context["use_thebe"] = True
 
     # Add the buttons to header_buttons
-    if len(launch_buttons_list) == 1:
-        # Remove the text since it's just a single button, want just an icon.
-        launch_buttons_list[0]["text"] = ""
-        header_buttons.extend(launch_buttons_list)
-    else:
-        for lb in launch_buttons_list:
-            lb["tooltip_placement"] = "left"
-        header_buttons.append(
-            {
-                "type": "group",
-                "tooltip": "Launch interactive content",
-                "icon": "fas fa-rocket",
-                "buttons": launch_buttons_list,
-                "label": "launch-buttons",
-            }
-        )
+    for lb in launch_buttons_list:
+        lb["tooltip_placement"] = "left"
+    header_buttons.append(
+        {
+            "type": "group",
+            "tooltip": "Launch interactive content",
+            "icon": "fas fa-rocket",
+            "buttons": launch_buttons_list,
+            "label": "launch-buttons",
+        }
+    )
 
 
 def _split_repo_url(url):

--- a/tests/test_build/header__repo-buttons--custom-branch.html
+++ b/tests/test_build/header__repo-buttons--custom-branch.html
@@ -1,9 +1,24 @@
 <div class="header-article__right">
- <a class="headerbtn" data-placement="bottom" data-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/foo?urlpath=tree/section1/ntbk.ipynb" title="Launch on Binder">
-  <span class="headerbtn__icon-container">
-   <img src="../_static/images/logo_binder.svg"/>
-  </span>
- </a>
+ <div class="menu-dropdown menu-dropdown-launch-buttons">
+  <button aria-label="Launch interactive content" class="headerbtn menu-dropdown__trigger">
+   <i class="fas fa-rocket">
+   </i>
+  </button>
+  <div class="menu-dropdown__content">
+   <ul>
+    <li>
+     <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/foo?urlpath=tree/section1/ntbk.ipynb" title="Launch on Binder">
+      <span class="headerbtn__icon-container">
+       <img src="../_static/images/logo_binder.svg"/>
+      </span>
+      <span class="headerbtn__text-container">
+       Binder
+      </span>
+     </a>
+    </li>
+   </ul>
+  </div>
+ </div>
  <button class="headerbtn" data-placement="bottom" data-toggle="tooltip" onclick="toggleFullScreen()" title="Fullscreen mode">
   <span class="headerbtn__icon-container">
    <i class="fas fa-expand">

--- a/tests/test_build/header__repo-buttons--custom-branch.html
+++ b/tests/test_build/header__repo-buttons--custom-branch.html
@@ -3,9 +3,6 @@
   <span class="headerbtn__icon-container">
    <img src="../_static/images/logo_binder.svg"/>
   </span>
-  <span class="headerbtn__text-container">
-   Binder
-  </span>
  </a>
  <button class="headerbtn" data-placement="bottom" data-toggle="tooltip" onclick="toggleFullScreen()" title="Fullscreen mode">
   <span class="headerbtn__icon-container">
@@ -17,9 +14,6 @@
   <span class="headerbtn__icon-container">
    <i class="fas fa-pencil-alt">
    </i>
-  </span>
-  <span class="headerbtn__text-container">
-   suggest edit
   </span>
  </a>
  <div class="menu-dropdown menu-dropdown-download-buttons">

--- a/tests/test_build/header__repo-buttons--one-on.html
+++ b/tests/test_build/header__repo-buttons--one-on.html
@@ -10,9 +10,6 @@
    <i class="fas fa-pencil-alt">
    </i>
   </span>
-  <span class="headerbtn__text-container">
-   suggest edit
-  </span>
  </a>
  <div class="menu-dropdown menu-dropdown-download-buttons">
   <button aria-label="Download this page" class="headerbtn menu-dropdown__trigger">


### PR DESCRIPTION
This fixes the icon image / `<i>` CSS in the header so that they behave properly when displayed by themselves and not as part of a dropdown. It also makes our launch buttons always use a dropdown so that we don't run into issues with logos that clash with the background.

fixes https://github.com/executablebooks/sphinx-book-theme/issues/514