### PR TITLE
ENH: Add support for ReadTheDocs popup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,3 @@ node_modules/
 # Editors
 .vscode/
 .idea
-
-# Programmatically created stuff
-docs/_static/rtd-data.js

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ node_modules/
 # Editors
 .vscode/
 .idea
+
+# Programmatically created stuff
+docs/_static/rtd-data.js

--- a/docs/_static/rtd-data.js
+++ b/docs/_static/rtd-data.js
@@ -1,0 +1,8 @@
+// Dummy data for testing ReadTheDocs footer insertion
+// This mimics RTD data for a project that uses both versions + languages
+var READTHEDOCS_DATA = {
+  project: "frc-docs",
+  version: "latest",
+  language: "en",
+  proxied_api_host: "https://readthedocs.org",
+};

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,7 +171,9 @@ for ifile in kitchen_sink_files:
 def setup(app):
     # -- To demonstrate ReadTheDocs switcher -------------------------------------
     # This links a few JS and CSS files that mimic the environment that RTD uses
-    # so that we can test RTD-like behavior.
+    # so that we can test RTD-like behavior. We don't need to run it on RTD and we
+    # don't wanted it loaded in GitHub Actions because it messes up the lighthouse
+    # results.
     if not os.environ.get("READTHEDOCS") and not os.environ.get("GITHUB_ACTIONS"):
         app.add_css_file(
             "https://assets.readthedocs.org/static/css/readthedocs-doc-embed.css"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,10 +120,10 @@ html_theme_options = {
     "use_download_button": True,
     "logo_only": True,
     "show_toc_level": 2,
-    "announcement": (
-        "⚠️The latest release refactored our HTML, "
-        "so double-check your custom CSS rules!⚠️"
-    ),
+    # "announcement": (
+    #     "⚠️The latest release refactored our HTML, "
+    #     "so double-check your custom CSS rules!⚠️"
+    # ),
     # For testing
     # "use_fullscreen_button": False,
     # "home_page_in_toc": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,7 +162,24 @@ for ifile in kitchen_sink_files:
     if not path_file.exists():
         print(f"Downloading kitchen sink file {ifile}")
         resp = request.urlopen(
-            f"https://github.com/sphinx-themes/sphinx-themes.org/raw/master/sample-docs/kitchen-sink/{ifile}"  # noqa
+            f"https://github.com/sphinx-themes/sphinx-themes.org/raw/master/sample-docs/kitchen-sink/{ifile}"  # noqa: E501
         )
         header = ".. DOWNLOADED FROM sphinx-themes.org, DO NOT MANUALLY EDIT\n"
         path_file.write_text(header + resp.read().decode())
+
+
+def setup(app):
+    # -- To demonstrate ReadTheDocs switcher -------------------------------------
+    if not os.environ.get("READTHEDOCS"):
+        app.add_css_file(
+            "https://assets.readthedocs.org/static/css/readthedocs-doc-embed.css"
+        )
+        app.add_css_file("https://assets.readthedocs.org/static/css/badge_only.css")
+
+        # Create the dummy data file so we can link it
+        # ref: https://github.com/readthedocs/readthedocs.org/blob/bc3e147770e5740314a8e8c33fec5d111c850498/readthedocs/core/static-src/core/js/doc-embed/footer.js  # noqa: E501
+        app.add_js_file("rtd-data.js")
+        app.add_js_file(
+            "https://assets.readthedocs.org/static/javascript/readthedocs-doc-embed.js",
+            priority=501,
+        )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,10 +120,10 @@ html_theme_options = {
     "use_download_button": True,
     "logo_only": True,
     "show_toc_level": 2,
-    # "announcement": (
-    #     "⚠️The latest release refactored our HTML, "
-    #     "so double-check your custom CSS rules!⚠️"
-    # ),
+    "announcement": (
+        "⚠️The latest release refactored our HTML, "
+        "so double-check your custom CSS rules!⚠️"
+    ),
     # For testing
     # "use_fullscreen_button": False,
     # "home_page_in_toc": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,8 @@ for ifile in kitchen_sink_files:
 
 def setup(app):
     # -- To demonstrate ReadTheDocs switcher -------------------------------------
+    # This links a few JS and CSS files that mimic the environment that RTD uses
+    # so that we can test RTD-like behavior.
     if not os.environ.get("READTHEDOCS"):
         app.add_css_file(
             "https://assets.readthedocs.org/static/css/readthedocs-doc-embed.css"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ def setup(app):
     # -- To demonstrate ReadTheDocs switcher -------------------------------------
     # This links a few JS and CSS files that mimic the environment that RTD uses
     # so that we can test RTD-like behavior.
-    if not os.environ.get("READTHEDOCS"):
+    if not os.environ.get("READTHEDOCS") and not os.environ.get("GITHUB_ACTIONS"):
         app.add_css_file(
             "https://assets.readthedocs.org/static/css/readthedocs-doc-embed.css"
         )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,6 @@ html_sidebars = {
         "categories.html",
         "archives.html",
         "sbt-sidebar-nav.html",
-        "sbt-sidebar-footer.html",
     ]
 }
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/customize/index.md
+++ b/docs/customize/index.md
@@ -50,7 +50,7 @@ The following options are available via `html_theme_options`
   - Show children in the navigation bar down to the depth listed here. See [](sidebar:navbar-depth).
 * - `extra_navbar`
   - str
-  - Extra HTML to add below the sidebar footer (if `sbt-sidebar-footer.html` is used in `html_sidebars`). See [](custom-footer).
+  - Extra HTML to add below the sidebar footer. See [](custom-footer).
 * - `extra_footer`
   - str
   - Extra HTML to add in the footer of each page.

--- a/docs/customize/sidebar-primary.md
+++ b/docs/customize/sidebar-primary.md
@@ -15,7 +15,7 @@ For example, the following configuration would include *only the footer* on page
 
 ```python
 html_sidebars = {
-    "posts/*": ["sbt-sidebar-footer.html"]
+    "posts/*": ["sbt-sidebar-nav.html"]
 }
 ```
 
@@ -23,7 +23,7 @@ You can also use `**` to apply a set of sidebars to **all** pages of your book. 
 
 ```python
 html_sidebars = {
-    "**": ["sbt-sidebar-nav.html", "sbt-sidebar-footer.html"]
+    "**": ["sbt-sidebar-nav.html"]
 }
 ```
 

--- a/src/sphinx_book_theme/assets/scripts/index.js
+++ b/src/sphinx_book_theme/assets/scripts/index.js
@@ -184,6 +184,25 @@ var initTooltips = () => {
 };
 
 /**
+ * MutationObserver to move the ReadTheDocs button
+ */
+var initRTDObserver = () => {
+  const mutated = (mutationList, observer) => {
+    mutationList.forEach((mutation) => {
+      if (mutation.type == "childList") {
+        mutation.addedNodes.forEach((node) => {
+          document.querySelector(".bd-sidebar__bottom").append(node);
+        });
+      }
+    });
+  };
+
+  const observer = new MutationObserver(mutated);
+  const config = { childList: true };
+  observer.observe(document.body, config);
+};
+
+/**
  * Functions that are called when a user takes some action.
  */
 window.initThebeSBT = initThebeSBT;
@@ -196,3 +215,4 @@ window.toggleFullScreen = toggleFullScreen;
 sbRunWhenDOMLoaded(initTooltips);
 sbRunWhenDOMLoaded(scrollToActive);
 sbRunWhenDOMLoaded(initTocHide);
+sbRunWhenDOMLoaded(initRTDObserver);

--- a/src/sphinx_book_theme/assets/scripts/index.js
+++ b/src/sphinx_book_theme/assets/scripts/index.js
@@ -186,31 +186,38 @@ var initTooltips = () => {
 /**
  * MutationObserver to move the ReadTheDocs button
  */
-var initRTDObserver = () => {
-  const mutated = (mutationList, observer) => {
+function initRTDObserver() {
+  const mutatedCallback = (mutationList, observer) => {
     mutationList.forEach((mutation) => {
-      if (mutation.type == "childList") {
+      // Check whether the mutation is for RTD, which will have a specific structure
+      if (mutation.addedNodes.length === 0) {
+        return;
+      }
+      if (mutation.addedNodes[0].data === undefined) {
+        return;
+      }
+      if (mutation.addedNodes[0].data.search("Inserted RTD Footer") != -1) {
         mutation.addedNodes.forEach((node) => {
-          document.querySelector(".bd-sidebar__bottom").append(node);
+          document.getElementById("rtd-footer-container").append(node);
         });
       }
     });
   };
 
-  const observer = new MutationObserver(mutated);
+  const observer = new MutationObserver(mutatedCallback);
   const config = { childList: true };
   observer.observe(document.body, config);
-};
+}
 
 /**
- * Functions that are called when a user takes some action.
+ * Set up callback functions for UI click actions
  */
 window.initThebeSBT = initThebeSBT;
 window.printPdf = printPdf;
 window.toggleFullScreen = toggleFullScreen;
 
 /**
- * Functions that are called when we load the page.
+ * Set up functions to load when the DOM is ready
  */
 sbRunWhenDOMLoaded(initTooltips);
 sbRunWhenDOMLoaded(scrollToActive);

--- a/src/sphinx_book_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/sphinx_book_theme/assets/styles/abstracts/_mixins.scss
@@ -39,3 +39,15 @@
     height: $header-article-height + 0.75em;
   }
 }
+
+/**
+ * Forces an element to fill the vertical screen space,
+ * but uses % on mobile because `vh` units behave weirdly on mobile.
+ * ref: https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser
+ */
+@mixin fill-vertical-screen-space {
+  height: 100vh; // On wide screens force this to take up the whole viewport
+  @media (max-width: $breakpoint-md) {
+    height: 100%; // So that height behaves properly on mobile
+  }
+}

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -27,7 +27,7 @@
     margin: auto;
     width: 1em;
     text-align: center;
-    font-size: 1.5rem; // Slightly larger for icons
+    font-size: 1.5em; // Slightly larger for icons
   }
 }
 
@@ -47,10 +47,9 @@
   opacity: 0;
   transform: translateX(-75%);
   transition: opacity 0.2s ease-out;
-  font-size: 1rem;
 
   // Spacing and position
-  width: 13em;
+  width: 10rem;
   border-radius: $box-border-radius;
   box-shadow: 0px 3px 10px 0px rgba(0, 0, 0, 0.25);
   padding: 0.5em;
@@ -61,11 +60,6 @@
   .headerbtn {
     justify-content: left;
     padding: 0.1rem 0rem;
-
-    img,
-    i {
-      font-size: 1.2em;
-    }
   }
 
   ul {
@@ -83,7 +77,13 @@
 
     &.headerbtn__text-container {
       flex-grow: 1;
+      margin-left: 0.5em;
     }
+  }
+
+  i,
+  img {
+    font-size: 1.2em; // Slightly smaller icons in a dropdown
   }
 }
 

--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -13,7 +13,6 @@
   color: $non-content-grey;
   cursor: pointer;
   border: none;
-  font-size: 1.4em;
   padding: 0.1rem 0.5rem; // Horizontal padding since labels have none
   margin: 0 0.1rem;
 
@@ -28,6 +27,7 @@
     margin: auto;
     width: 1em;
     text-align: center;
+    font-size: 1.5rem; // Slightly larger for icons
   }
 }
 
@@ -47,6 +47,7 @@
   opacity: 0;
   transform: translateX(-75%);
   transition: opacity 0.2s ease-out;
+  font-size: 1rem;
 
   // Spacing and position
   width: 13em;
@@ -55,7 +56,6 @@
   padding: 0.5em;
 
   // Style
-  font-size: 0.9em;
   background-color: white;
 
   .headerbtn {
@@ -64,7 +64,7 @@
 
     img,
     i {
-      font-size: 0.9em;
+      font-size: 1.2em;
     }
   }
 

--- a/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
@@ -25,6 +25,11 @@
       color: $non-content-grey;
       border-top: $border-thin;
 
+      @media (max-width: $breakpoint-md) {
+        // Slightly bigger on mobile so the button is more noticeable.
+        height: 3rem;
+      }
+
       &:hover {
         background-color: rgba(
           var(--pst-color-sidebar-expander-background-hover),

--- a/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
@@ -1,0 +1,48 @@
+/**
+ * ReadTheDocs pop-up menu over-rides.
+ * We nest everything under `.bd-sidebar` so that we use more selective
+ * selectors than what RTD CSS uses.
+ */
+.bd-sidebar {
+  // Extra selective selector to over-ride RTD
+  .rst-versions.rst-badge {
+    position: unset;
+
+    &.shift-up .rst-current-version {
+      background-color: black;
+    }
+
+    // This is the top part of the dropdown, lists the current versions
+    .rst-current-version {
+      display: flex;
+      align-items: center;
+      gap: 0.2rem;
+      height: 2.5rem;
+      background-color: $non-content-grey;
+      transition: background-color 0.2s ease-out;
+      color: white;
+
+      &:hover {
+        background-color: black;
+        cursor: pointer;
+      }
+
+      .fa-book {
+        float: unset;
+        margin-right: auto;
+
+        &:after {
+          content: "ReadTheDocs";
+          font-family: sans-serif;
+          font-weight: bold;
+        }
+      }
+    }
+
+    .rst-other-versions {
+      dt {
+        color: #ccc;
+      }
+    }
+  }
+}

--- a/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
@@ -12,29 +12,29 @@
   // Extra selective selector to over-ride RTD
   .rst-versions.rst-badge {
     position: unset;
-    border-top-left-radius: 0.5em;
-    border-top-right-radius: 0.5em;
     font-size: 0.9em;
-
-    &.shift-up .rst-current-version {
-      background-color: black;
-    }
 
     // This is the top part of the dropdown, lists the current versions
     .rst-current-version {
       display: flex;
       align-items: center;
-      border-top-left-radius: 0.5em;
-      border-top-right-radius: 0.5em;
       gap: 0.2rem;
-      height: 2rem;
-      background-color: $non-content-grey;
+      height: 2.5rem;
       transition: background-color 0.2s ease-out;
-      color: white;
+      background-color: white;
+      color: $non-content-grey;
+      border-top: $border-thin;
 
       &:hover {
-        background-color: black;
+        background-color: rgba(
+          var(--pst-color-sidebar-expander-background-hover),
+          1
+        );
         cursor: pointer;
+      }
+
+      .fa {
+        color: $non-content-grey;
       }
 
       .fa-book {

--- a/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
@@ -7,6 +7,8 @@
   // Extra selective selector to over-ride RTD
   .rst-versions.rst-badge {
     position: unset;
+    border-top-left-radius: 0.5em;
+    border-top-right-radius: 0.5em;
 
     &.shift-up .rst-current-version {
       background-color: black;
@@ -16,6 +18,8 @@
     .rst-current-version {
       display: flex;
       align-items: center;
+      border-top-left-radius: 0.5em;
+      border-top-right-radius: 0.5em;
       gap: 0.2rem;
       height: 2.5rem;
       background-color: $non-content-grey;

--- a/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/_readthedocs.scss
@@ -4,11 +4,17 @@
  * selectors than what RTD CSS uses.
  */
 .bd-sidebar {
+  // Parent container for everything else
+  div#rtd-footer-container {
+    position: sticky;
+    bottom: 0;
+  }
   // Extra selective selector to over-ride RTD
   .rst-versions.rst-badge {
     position: unset;
     border-top-left-radius: 0.5em;
     border-top-right-radius: 0.5em;
+    font-size: 0.9em;
 
     &.shift-up .rst-current-version {
       background-color: black;
@@ -21,7 +27,7 @@
       border-top-left-radius: 0.5em;
       border-top-right-radius: 0.5em;
       gap: 0.2rem;
-      height: 2.5rem;
+      height: 2rem;
       background-color: $non-content-grey;
       transition: background-color 0.2s ease-out;
       color: white;
@@ -39,6 +45,7 @@
           content: "ReadTheDocs";
           font-family: sans-serif;
           font-weight: bold;
+          margin-left: 0.2em;
         }
       }
     }

--- a/src/sphinx_book_theme/assets/styles/index.scss
+++ b/src/sphinx_book_theme/assets/styles/index.scss
@@ -46,6 +46,7 @@
 @import "extensions/ablog";
 @import "extensions/myst-nb";
 @import "extensions/sphinx-tabs";
+@import "extensions/readthedocs";
 @import "extensions/thebe";
 
 // Page-specific CSS

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -2,7 +2,7 @@
 * Left Nav Bar *
 *********************************************/
 #site-navigation {
-  height: 100vh !important;
+  height: 100vh; // On wide screens force this to take up the whole viewport
   padding-top: 0;
   width: $leftbar-width-wide;
   font-size: var(--sbt-sidebar-font-size);
@@ -13,6 +13,15 @@
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
 
+  @media (max-width: $breakpoint-md) {
+    height: 100%; // So that height behaves properly on mobile
+    position: fixed;
+    width: $leftbar-width-mobile;
+    max-width: 300px;
+    font-size: 1.2em;
+    z-index: $zindex-offcanvas;
+  }
+
   .bd-sidebar__top {
     padding: 0 1rem 0rem 1.5rem;
     overflow-y: auto;
@@ -22,14 +31,6 @@
 
   .bd-sidebar__bottom {
     margin-top: auto;
-  }
-
-  @media (max-width: $breakpoint-md) {
-    position: fixed;
-    width: $leftbar-width-mobile;
-    max-width: 300px;
-    font-size: 1.2em;
-    z-index: $zindex-offcanvas;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -10,9 +10,7 @@
   border-right: $border-thin;
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
-
-  @include scrollbar-style();
-  @include scrollbar-on-hover();
+  overflow-y: unset; // To over-ride the pydata theme and allow for sticky items
   @include fill-vertical-screen-space();
 
   // On mobile, behave like a slide-out drawer
@@ -24,6 +22,16 @@
     z-index: $zindex-offcanvas;
   }
 
+  // The container for the sidebar content (stuff that isn't the RTD button)
+  .bd-sidebar__content {
+    overflow-y: auto;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    @include scrollbar-style();
+    @include scrollbar-on-hover();
+  }
+
   // Apply some basic padding so the dropdown buttons don't overlap w/ scrollbar
   .bd-sidebar__top,
   .bd-sidebar__bottom {
@@ -33,6 +41,7 @@
   // This should always snap to the bottom even if there's no sidebar content
   .bd-sidebar__bottom {
     margin-top: auto;
+    margin-bottom: 2em;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -3,6 +3,7 @@
 *********************************************/
 #site-navigation {
   height: 100vh !important;
+  padding-top: 0;
   width: $leftbar-width-wide;
   font-size: var(--sbt-sidebar-font-size);
   top: 0px !important;
@@ -12,8 +13,16 @@
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
 
-  @include scrollbar-style();
-  @include scrollbar-on-hover();
+  .bd-sidebar__top {
+    padding: 0 1rem 0rem 1.5rem;
+    overflow-y: auto;
+    @include scrollbar-style();
+    @include scrollbar-on-hover();
+  }
+
+  .bd-sidebar__bottom {
+    margin-top: auto;
+  }
 
   @media (max-width: $breakpoint-md) {
     position: fixed;

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -2,7 +2,6 @@
 * Left Nav Bar *
 *********************************************/
 #site-navigation {
-  height: 100vh; // On wide screens force this to take up the whole viewport
   padding-top: 0;
   width: $leftbar-width-wide;
   font-size: var(--sbt-sidebar-font-size);
@@ -13,8 +12,10 @@
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
 
+  @include fill-vertical-screen-space();
+
+  // On mobile, behave like a slide-out drawer
   @media (max-width: $breakpoint-md) {
-    height: 100%; // So that height behaves properly on mobile
     position: fixed;
     width: $leftbar-width-mobile;
     max-width: 300px;

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -6,7 +6,7 @@
   width: $leftbar-width-wide;
   font-size: var(--sbt-sidebar-font-size);
   top: 0px !important;
-  overflow-y: auto;
+  overflow-y: unset; // Unset the pydata value this so that the footer can be sticky
   background: white;
   border-right: $border-thin;
   transition: margin-left $animation-time ease 0s,
@@ -32,6 +32,8 @@
 
   .bd-sidebar__bottom {
     margin-top: auto;
+    position: sticky;
+    bottom: 0;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-primary.scss
@@ -6,12 +6,13 @@
   width: $leftbar-width-wide;
   font-size: var(--sbt-sidebar-font-size);
   top: 0px !important;
-  overflow-y: unset; // Unset the pydata value this so that the footer can be sticky
   background: white;
   border-right: $border-thin;
   transition: margin-left $animation-time ease 0s,
     opacity $animation-time ease 0s, visibility $animation-time ease 0s;
 
+  @include scrollbar-style();
+  @include scrollbar-on-hover();
   @include fill-vertical-screen-space();
 
   // On mobile, behave like a slide-out drawer
@@ -23,17 +24,15 @@
     z-index: $zindex-offcanvas;
   }
 
-  .bd-sidebar__top {
+  // Apply some basic padding so the dropdown buttons don't overlap w/ scrollbar
+  .bd-sidebar__top,
+  .bd-sidebar__bottom {
     padding: 0 1rem 0rem 1.5rem;
-    overflow-y: auto;
-    @include scrollbar-style();
-    @include scrollbar-on-hover();
   }
 
+  // This should always snap to the bottom even if there's no sidebar content
   .bd-sidebar__bottom {
     margin-top: auto;
-    position: sticky;
-    bottom: 0;
   }
 
   nav ul.nav {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -21,7 +21,7 @@
     top: 0;
     right: 0;
     position: fixed;
-    height: 100vh;
+    height: 100%;
     width: $toc-width-mobile;
     max-width: 300px;
     background-color: white;

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/components/sbt-sidebar-footer.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/components/sbt-sidebar-footer.html
@@ -1,6 +1,0 @@
-{% if theme_navbar_footer_text %}{% set theme_extra_navbar=theme_navbar_footer_text %}{% endif %} <!-- To handle the deprecated key -->
-{% if theme_extra_navbar %}
-<div class="navbar_extra_footer">
-  {{ theme_extra_navbar }}
-</div>
-{% endif %}

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -29,15 +29,15 @@
 {% block docs_sidebar %}
 <!-- Sidebar -->
 <div class="bd-sidebar noprint{% if is_single_page %} single-page{% endif %}" id="site-navigation">
+    {%- if not is_single_page %}
     <div class="bd-sidebar__top">
-        {%- if not is_single_page %}
-            {%- include "sections/sidebar.html" -%}
-        {%- endif %}
+        {%- include "sections/sidebar.html" -%}
     </div>
     <div class="bd-sidebar__bottom">
-        {#- This is a placeholder for if/when we want to put things here #}
-        {#- It will make the top section shrink if it exists -#}
+        {# In the future we can add other bottom elements, for now just RTD #}
+        <div id="rtd-footer-container"></div>
     </div>
+    {%- endif %}
 </div>
 {% endblock %}
 

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -30,16 +30,18 @@
 <!-- Sidebar -->
 <div class="bd-sidebar noprint{% if is_single_page %} single-page{% endif %}" id="site-navigation">
     {%- if not is_single_page %}
-    <div class="bd-sidebar__top">
-        {%- include "sections/sidebar.html" -%}
-    </div>
-    <div class="bd-sidebar__bottom">
-        {% if theme_navbar_footer_text %}{% set theme_extra_navbar=theme_navbar_footer_text %}{% endif %} <!-- To handle the deprecated key -->
-        {% if theme_extra_navbar %}
-        <div class="navbar_extra_footer">
-          {{ theme_extra_navbar }}
+    <div class="bd-sidebar__content">
+        <div class="bd-sidebar__top">
+            {%- include "sections/sidebar.html" -%}
         </div>
-        {% endif %}
+        <div class="bd-sidebar__bottom">
+            {% if theme_navbar_footer_text %}{% set theme_extra_navbar=theme_navbar_footer_text %}{% endif %} <!-- To handle the deprecated key -->
+            {% if theme_extra_navbar %}
+            <div class="navbar_extra_footer">
+            {{ theme_extra_navbar }}
+            </div>
+            {% endif %}
+        </div>
     </div>
     <div id="rtd-footer-container"></div>
     {%- endif %}

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -28,10 +28,16 @@
 <!-- Docs TOC is "d-none d-xl-block col-xl-2" -->
 {% block docs_sidebar %}
 <!-- Sidebar -->
-<div class="pl-4 pr-3 bd-sidebar site-navigation noprint {% if is_single_page %} single-page{% endif %}" id="site-navigation">
-    {% if not is_single_page %}
-        {%- include "sections/sidebar.html" -%}
-    {%- endif %}
+<div class="bd-sidebar noprint{% if is_single_page %} single-page{% endif %}" id="site-navigation">
+    <div class="bd-sidebar__top">
+        {%- if not is_single_page %}
+            {%- include "sections/sidebar.html" -%}
+        {%- endif %}
+    </div>
+    <div class="bd-sidebar__bottom">
+        {#- This is a placeholder for if/when we want to put things here #}
+        {#- It will make the top section shrink if it exists -#}
+    </div>
 </div>
 {% endblock %}
 

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -34,9 +34,14 @@
         {%- include "sections/sidebar.html" -%}
     </div>
     <div class="bd-sidebar__bottom">
-        {# In the future we can add other bottom elements, for now just RTD #}
-        <div id="rtd-footer-container"></div>
+        {% if theme_navbar_footer_text %}{% set theme_extra_navbar=theme_navbar_footer_text %}{% endif %} <!-- To handle the deprecated key -->
+        {% if theme_extra_navbar %}
+        <div class="navbar_extra_footer">
+          {{ theme_extra_navbar }}
+        </div>
+        {% endif %}
     </div>
+    <div id="rtd-footer-container"></div>
     {%- endif %}
 </div>
 {% endblock %}

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/theme.conf
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 inherit = pydata_sphinx_theme
 pygments_style = tango
-sidebars = sidebar-logo.html, search-field.html, sbt-sidebar-nav.html, sbt-sidebar-footer.html
+sidebars = sidebar-logo.html, search-field.html, sbt-sidebar-nav.html
 stylesheet = styles/sphinx-book-theme.css
 
 [options]


### PR DESCRIPTION
This adds some JS that "places" the ReadTheDocs popup in the sidebar so that it looks a bit nicer on page load. It creates a "top" and a "bottom" of our sidebar, so that things stay at the bottom regardless of the content at the top. Also adds a bunch of CSS to style the ReadTheDocs popup properly.

![chrome_AdGNLQl6JI](https://user-images.githubusercontent.com/1839645/157593818-f56d3ad3-5763-4bea-b73b-034faf8d2165.gif)

