### PR TITLE
A simple sidenote, marginnote functionality

### DIFF
--- a/docs/content-blocks.md
+++ b/docs/content-blocks.md
@@ -84,6 +84,17 @@ but I'll stop here.
 ```
 ````
 `````
+## Examples of marginnote and sidenotes
+
+One of the most distinctive features of Tufte’s style is his extensive use of sidenotes{sidenote}`This is a sidenote`.
+Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page,
+but instead display off to the side in the margin. Here is another sidenote{sidenote}`This is a second sidenote`.
+
+If you want a sidenote without footnote-style numberings, then you want a margin note.
+{marginnote}`This is a margin note. Notice there isn’t a number preceding the note.` On large screens,
+a margin note is just a sidenote that omits the reference number.
+This lessens the distracting effect taking away from the flow of the main text,
+but can increase the cognitive load of matching a margin note to its referent text.
 
 ## Sidebars
 

--- a/docs/content-blocks.md
+++ b/docs/content-blocks.md
@@ -84,32 +84,8 @@ but I'll stop here.
 ```
 ````
 `````
-## Examples of marginnote and sidenotes
 
-One of the most distinctive features of Tufte’s style is his extensive use of sidenotes{sidenote}`This is a sidenote`.
-Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page,
-but instead display off to the side in the margin. Here is another sidenote{sidenote}`This is a second sidenote`.
-
-If you want a sidenote without footnote-style numberings, then you want a margin note.
-{marginnote}`This is a margin note. Notice there isn’t a number preceding the note.` On large screens,
-a margin note is just a sidenote that omits the reference number.
-This lessens the distracting effect taking away from the flow of the main text,
-but can increase the cognitive load of matching a margin note to its referent text.
-
-## Sidebars
-
-There are two different kinds of sidebar-like content in `sphinx-book-theme`,
-typical `{sidebar}` directives, as well as a theme-specific `{margin}` directive.
-This section covers both. Both allow you to place extra content
-separately from your main content.
-
-```{tip}
-Sidebar content will generally overlap with the white space where your site's
-table of contents lives. When the reader scrolls sidebar content into view, the
-right TOC should hide itself automatically.
-```
-
-### Margin content
+## Margin content
 
 You can specify content that should exist in the right margin. This will behave
 like a regular sidebar until the screen hits a certain width, at which point this
@@ -117,7 +93,7 @@ content will "pop out" to the right white space.
 
 There are two ways to add content to the margin: via the `{margin}` directive, and via adding CSS classes to your own content.
 
-#### Use a `{margin}` directive to add margin content
+### The `{margin}` directive - block-level margin content
 
 The `{margin}` directive allows you to create margin content with your own title and content block.
 It is a wrapper around the Sphinx `{sidebar}` directive, and largely does its magic via CSS classes (see below).
@@ -134,7 +110,52 @@ Here is my margin content, it is pretty cool!
 ```
 ````
 
-#### Use CSS classes to add margin content
+### The `{marginnote}` and `{sidenote}` roles - inline margin content
+
+In addition to block-level margin content, this theme has support for [Tufte-stype margin / side notes](https://edwardtufte.github.io/tufte-css/){sidenote}`For example, this is a sidenote`.
+
+Sidenotes are numbered, and behave like footnotes, except they live in the margin and don’t force the reader to jump their eye to the bottom of the page.
+On narrow screens, sidenotes are hidden until a user clicks the number.
+If you're on a mobile device, try clicking this sidenote{sidenote}`This is a second sidenote`.
+
+Marginnotes are not numbered, but behave the same way as sidenotes.
+On mobile devices a symbol will be displayed that will display the marginnote when clicked.
+For example{marginnote}`This is a margin note. Notice there isn’t a number preceding the note.`.
+
+
+### Figure captions in the margin
+
+You can configure figures to use the margin for captions.
+Here is a figure with a caption to the right.
+
+```{figure} images/cool.jpg
+---
+width: 60%
+figclass: margin-caption
+alt: My figure text
+name: myfig5
+---
+And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-).
+```
+
+And the text that produced it:
+
+````
+```{figure} images/cool.jpg
+---
+width: 60%
+figclass: margin-caption
+alt: My figure text
+name: myfig5
+---
+And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-)
+```
+````
+
+We can reference the figure with {ref}`this reference <myfig5>`. Or a numbered reference like
+{numref}`myfig5`.
+
+### CSS classes for custom margin content
 
 You may also directly add CSS classes to elements on your page in order to make them behave like margin content.
 To do so, add the `margin` CSS class to any element on the page.
@@ -185,65 +206,10 @@ And here is my figure caption
 We can reference the figure with {ref}`myfig4`. Or a numbered reference like
 {numref}`myfig4`.
 
-#### Figure captions in the margin
-
-You can configure figures to use the margin for captions.
-Here is a figure with a caption to the right.
-
-```{figure} images/cool.jpg
----
-width: 60%
-figclass: margin-caption
-alt: My figure text
-name: myfig5
----
-And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-).
-```
-
-And the text that produced it:
-
-````
-```{figure} images/cool.jpg
----
-width: 60%
-figclass: margin-caption
-alt: My figure text
-name: myfig5
----
-And here is my figure caption, if you look to the left, you can see that COOL is in big red letters. But you probably already noticed that, really I am just taking up space to see how the margin caption looks like when it is really long :-)
-```
-````
-
-We can reference the figure with {ref}`this reference <myfig5>`. Or a numbered reference like
-{numref}`myfig5`.
-
-### Content sidebars
-
-Content sidebars exist in-line with your text, but allow the rest of the
-page to flow around them, rather than moving to the right margin.
-To add content sidebars, use this syntax:
-
-````{sidebar} **My sidebar title**
-```{note}
-Here is my sidebar content, it is pretty cool!
-```
-![](images/cool.jpg)
-````
-
-Note how the content wraps around the sidebar to the right.
-However, the sidebar text will still be in line with your content. There are
-certain kinds of elements, such as "note" blocks and code cells, that may
-clash with your sidebar. If this happens, try using a `{margin}` instead.
-
-````
-```{sidebar} **My sidebar title**
-Here is my sidebar content, it is pretty cool!
-```
-````
 
 ### Adding content to margins and sidebars
 
-Sidebar/margin content can include all kinds of things, such as code blocks:
+Margin content can include all kinds of things, such as code blocks:
 
 ````{margin} Code blocks in margins
 ```python
@@ -277,6 +243,7 @@ Wow, a note with an image in a margin!
 ````
 `````
 
+
 ## Full-width content
 
 Full-width content extends into the right margin, making it stand out against
@@ -303,3 +270,28 @@ If you are using a Jupyter Notebook as inputs to your documentation using the
 [MyST-NB extension](https://myst-nb.readthedocs.io/en/latest/), you can trigger
 this behavior with a code cell by adding a `full-width` tag to the cell.
 ```
+
+
+## Sidebars
+
+Content sidebars exist in-line with your text, but allow the rest of the
+page to flow around them, rather than moving to the right margin.
+To add content sidebars, use this syntax:
+
+````{sidebar} **My sidebar title**
+```{note}
+Here is my sidebar content, it is pretty cool!
+```
+![](images/cool.jpg)
+````
+
+Note how the content wraps around the sidebar to the right.
+However, the sidebar text will still be in line with your content. There are
+certain kinds of elements, such as "note" blocks and code cells, that may
+clash with your sidebar. If this happens, try using a `{margin}` instead.
+
+````
+```{sidebar} **My sidebar title**
+Here is my sidebar content, it is pretty cool!
+```
+````

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -269,7 +269,9 @@ your Jupyter Book as well!
 The traditional Jupyter Notebook interface allows you to toggle **output scrolling**
 for your cells. This allows you to visualize part of a long output without it taking up
 the entire page.
+Let us see how sidenotes{sidenote}`This is sidenote text` look like.
 
+Here is another sidenote for you{sidenote}`This is a second sidenote text`. Nothing too fancy.
 You can trigger this behavior in Jupyter Book by adding the following
 tag to a cell's metadata:
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -260,7 +260,17 @@ your Jupyter Book as well!
 !jupyter -h
 ```
 
+## Examples of marginnote and sidenotes
 
+One of the most distinctive features of Tufte’s style is his extensive use of sidenotes{sidenote}`This is a sidenote`.
+Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page,
+but instead display off to the side in the margin. Here is another sidenote{sidenote}`This is a second sidenote`.
+
+If you want a sidenote without footnote-style numberings, then you want a margin note.
+{marginnote}`This is a margin note. Notice there isn’t a number preceding the note.` On large screens,
+a margin note is just a sidenote that omits the reference number.
+This lessens the distracting effect taking away from the flow of the main text,
+but can increase the cognitive load of matching a margin note to its referent text.
 
 ## Formatting code cells
 
@@ -269,9 +279,7 @@ your Jupyter Book as well!
 The traditional Jupyter Notebook interface allows you to toggle **output scrolling**
 for your cells. This allows you to visualize part of a long output without it taking up
 the entire page.
-Let us see how sidenotes{sidenote}`This is sidenote text` look like.
 
-Here is another sidenote for you{sidenote}`This is a second sidenote text`. Nothing too fancy.
 You can trigger this behavior in Jupyter Book by adding the following
 tag to a cell's metadata:
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -260,6 +260,8 @@ your Jupyter Book as well!
 !jupyter -h
 ```
 
+
+
 ## Formatting code cells
 
 ### Scrolling cell outputs

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -260,18 +260,6 @@ your Jupyter Book as well!
 !jupyter -h
 ```
 
-## Examples of marginnote and sidenotes
-
-One of the most distinctive features of Tufte’s style is his extensive use of sidenotes{sidenote}`This is a sidenote`.
-Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page,
-but instead display off to the side in the margin. Here is another sidenote{sidenote}`This is a second sidenote`.
-
-If you want a sidenote without footnote-style numberings, then you want a margin note.
-{marginnote}`This is a margin note. Notice there isn’t a number preceding the note.` On large screens,
-a margin note is just a sidenote that omits the reference number.
-This lessens the distracting effect taking away from the flow of the main text,
-but can increase the cognitive load of matching a margin note to its referent text.
-
 ## Formatting code cells
 
 ### Scrolling cell outputs

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -163,6 +163,19 @@ class Margin(Sidebar):
         return nodes
 
 
+class MarginNote(SphinxRole):
+    """Goes in the margin to the right of the page."""
+
+    def run(self):
+        para = docutil_nodes.inline()
+        para.attributes["classes"].append("marginnote")
+        para.append(docutil_nodes.Text(self.text))
+
+        marginnote = SideNoteNode()
+        marginnote.attributes["names"].append("marginnote-role")
+        return [marginnote, para], []
+
+
 class SideNote(SphinxRole):
     """Goes in the margin to the right of the page,
     along with superscript reference number.
@@ -182,7 +195,7 @@ class SideNote(SphinxRole):
         self.docname = self.env.docname
 
         superscript = docutil_nodes.superscript("", self.index)
-        para = docutil_nodes.inline(superscript)
+        para = docutil_nodes.inline()
         para.attributes["classes"].append("sidenote")
         para.extend([superscript, docutil_nodes.Text(self.text)])
 
@@ -220,6 +233,7 @@ def setup(app: Sphinx):
     app.add_directive("margin", Margin)
 
     # Roles
+    app.add_role("marginnote", MarginNote())
     app.add_role("sidenote", SideNote())
 
     # Update templates for sidebar

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -9,7 +9,7 @@ from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.locale import get_translation
 from sphinx.util import logging
-
+from sphinx.util.docutils import SphinxRole
 from .header_buttons import prep_header_buttons, add_header_buttons
 from .header_buttons.launch import add_launch_buttons
 
@@ -162,6 +162,31 @@ class Margin(Sidebar):
         return nodes
 
 
+class SideNote(SphinxRole):
+    """Goes in the margin to the right of the page,
+    along with superscript reference number.
+    """
+
+    index = 0
+    docname = None
+
+    def run(self):
+        """Each sidenote comes with a superscripted index. Which resets itself in every page.
+        The sidenote element itself is just a span for now.
+        """
+        if not self.docname or self.env.docname == self.docname:
+            self.index += 1
+        else:
+            self.index = 1
+        self.docname = self.env.docname
+
+        superscript = nodes.superscript("", self.index)
+        para = nodes.inline(superscript)
+        para.attributes["classes"].append("sidenote")
+        para.extend([superscript, nodes.Text(self.text)])
+        return [superscript, para], []
+
+
 def setup(app: Sphinx):
     # Register theme
     theme_dir = get_html_theme_path()
@@ -185,6 +210,9 @@ def setup(app: Sphinx):
 
     # Directives
     app.add_directive("margin", Margin)
+
+    # Roles
+    app.add_role("sidenote", SideNote())
 
     # Update templates for sidebar
     app.config.templates_path.append(os.path.join(theme_dir, "components"))

--- a/src/sphinx_book_theme/assets/styles/content/_margin.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_margin.scss
@@ -38,8 +38,33 @@ $content-fullwidth-width: percentage(100% / $content-max-width);
   }
 }
 
+label.margin-toggle {
+  @media (max-width: $breakpoint-md) {
+    cursor: pointer;
+  }
+}
+
+input.margin-toggle {
+  display: none;
+  @media (max-width: $breakpoint-md) {
+    &:checked + .sidenote {
+      display: block;
+      float: left;
+      left: 1rem;
+      clear: both;
+      width: 95%;
+      margin: 1rem 2.5%;
+      position: relative;
+    }
+  }
+}
+
 span.sidenote {
   @include margin-content();
+  border-left: none;
+  @media (max-width: $breakpoint-md) {
+    display: none;
+  }
 }
 
 div.margin,

--- a/src/sphinx_book_theme/assets/styles/content/_margin.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_margin.scss
@@ -39,15 +39,26 @@ $content-fullwidth-width: percentage(100% / $content-max-width);
 }
 
 label.margin-toggle {
+  margin-bottom: 0em;
+  &.marginnote-label {
+    display: none;
+  }
   @media (max-width: $breakpoint-md) {
     cursor: pointer;
+    &.marginnote-label {
+      display: inline;
+      &:after {
+        content: "\2295";
+      }
+    }
   }
 }
 
 input.margin-toggle {
   display: none;
   @media (max-width: $breakpoint-md) {
-    &:checked + .sidenote {
+    &:checked + .sidenote,
+    &:checked + .marginnote {
       display: block;
       float: left;
       left: 1rem;
@@ -59,7 +70,8 @@ input.margin-toggle {
   }
 }
 
-span.sidenote {
+span.sidenote,
+span.marginnote {
   @include margin-content();
   border-left: none;
   @media (max-width: $breakpoint-md) {

--- a/src/sphinx_book_theme/assets/styles/content/_margin.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_margin.scss
@@ -38,6 +38,10 @@ $content-fullwidth-width: percentage(100% / $content-max-width);
   }
 }
 
+span.sidenote {
+  @include margin-content();
+}
+
 div.margin,
 aside.margin,
 .cell.tag_popout,

--- a/src/sphinx_book_theme/nodes.py
+++ b/src/sphinx_book_theme/nodes.py
@@ -1,0 +1,42 @@
+from docutils import nodes
+from sphinx.application import Sphinx
+from typing import Any, cast
+from sphinx.writers.latex import LaTeXTranslator
+
+
+class SideNoteNode(nodes.Element):
+    """A node that will not be rendered."""
+
+    def __init__(self, rawsource="", *children, **attributes):
+        super().__init__("", **attributes)
+
+    @classmethod
+    def add_node(cls, app: Sphinx) -> None:
+        add_node = cast(Any, app.add_node)  # has the wrong typing for sphinx<4
+        add_node(
+            cls,
+            override=True,
+            html=(visit_SideNoteNode, depart_SideNoteNode),
+            latex=(visit_SideNoteNode, depart_SideNoteNode),
+        )
+
+
+def visit_SideNoteNode(self, node):
+    if isinstance(self, LaTeXTranslator):
+        pass
+    else:
+        tagid = node.attributes["names"][0]
+        self.body.append(f"<label for='{tagid}' class='margin-toggle'>")
+        self.body.append(self.starttag(node, "span"))
+
+
+def depart_SideNoteNode(self, node):
+    if isinstance(self, LaTeXTranslator):
+        pass
+    else:
+        tagid = node.attributes["names"][0]
+        self.body.append("</span>\n\n")
+        self.body.append("</label>")
+        self.body.append(
+            f"<input type='checkbox' id='{tagid}' name='{tagid}' class='margin-toggle'>"
+        )

--- a/src/sphinx_book_theme/nodes.py
+++ b/src/sphinx_book_theme/nodes.py
@@ -26,8 +26,13 @@ def visit_SideNoteNode(self, node):
         pass
     else:
         tagid = node.attributes["names"][0]
-        self.body.append(f"<label for='{tagid}' class='margin-toggle'>")
-        self.body.append(self.starttag(node, "span"))
+        if "marginnote" in tagid:
+            self.body.append(
+                f"<label for='{tagid}' class='margin-toggle marginnote-label'>"
+            )
+        else:
+            self.body.append(f"<label for='{tagid}' class='margin-toggle'>")
+            self.body.append(self.starttag(node, "span"))
 
 
 def depart_SideNoteNode(self, node):
@@ -35,7 +40,8 @@ def depart_SideNoteNode(self, node):
         pass
     else:
         tagid = node.attributes["names"][0]
-        self.body.append("</span>\n\n")
+        if "sidenote" in tagid:
+            self.body.append("</span>\n\n")
         self.body.append("</label>")
         self.body.append(
             f"<input type='checkbox' id='{tagid}' name='{tagid}' class='margin-toggle'>"


### PR DESCRIPTION
**EDIT**: Please refer to the other PR for "footnotes vis sidenotes": https://github.com/executablebooks/sphinx-book-theme/pull/546

So, I wrote up a simple sidenote and marginnote role here. Trying to mimic https://edwardtufte.github.io/tufte-css/ . Note that we can't have references inside sidenotes, as it is a role and not a directive.

As discussed in  https://github.com/executablebooks/jupyter-book/issues/598

<img width="1104" alt="Screen Shot 2022-03-16 at 11 57 25 am" src="https://user-images.githubusercontent.com/6542997/158496089-cf8e9dd2-47b1-4543-82d0-7c23379b85e3.png">


For smaller screens it will look like this (for sidenote and marginnote):



https://user-images.githubusercontent.com/6542997/158496105-97921c63-bc31-49fd-aba9-15100664dd56.mov






I will keep the PR open for review though, even though it's not ready, for people to deliberate on whether the code is getting bloated here and we should shift it to a new extension. 

cc: @choldgraf @mmcky 