### PR TITLE
ENH: Add CSS for comments libraries

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ reference/notebooks
 reference/thebe
 reference/blog
 reference/api-numpy
+reference/comments
 ```
 
 # Inspiration

--- a/docs/reference/comments.md
+++ b/docs/reference/comments.md
@@ -1,0 +1,47 @@
+# Comments
+
+This page demonstrates functionality of comment libraries.
+The theme does not change the style of these libraries, but should hide their UI elements on print.
+
+## Hypothes.is
+
+You can activate hypothes.is with the following JS:
+
+```
+<script async="async" src="https://hypothes.is/embed.js"></script>
+```
+
+```{raw} html
+<script async="async" src="https://hypothes.is/embed.js"></script>
+```
+
+## Utterances
+
+You can activate utterances with the following JS:
+
+```
+<script
+   type="text/javascript"
+   src="https://utteranc.es/client.js"
+   async="async"
+   repo="executablebooks/jupyter-book"
+   issue-term="pathname"
+   theme="github-light"
+   label="💬 comment"
+   crossorigin="anonymous"
+/>
+```
+
+
+```{raw} html
+<script
+   type="text/javascript"
+   src="https://utteranc.es/client.js"
+   async="async"
+   repo="executablebooks/jupyter-book"
+   issue-term="pathname"
+   theme="github-light"
+   label="💬 comment"
+   crossorigin="anonymous"
+/>
+```

--- a/src/sphinx_book_theme/assets/styles/extensions/comments.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/comments.scss
@@ -1,0 +1,10 @@
+/**
+ * Comment JavaScript libraries
+ */
+// In general we want to hide any comment libraries on print
+@media only print {
+  hypothesis-sidebar,
+  div.utterances {
+    display: none !important;
+  }
+}

--- a/src/sphinx_book_theme/assets/styles/extensions/comments.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/comments.scss
@@ -1,6 +1,9 @@
 /**
  * Comment JavaScript libraries
- */
+  * Libraries supported here are:
+  * - Hypothesis.is : https://web.hypothes.is/
+  * - Utteranc.es : https://utteranc.es/
+  */
 // In general we want to hide any comment libraries on print
 @media only print {
   hypothesis-sidebar,

--- a/src/sphinx_book_theme/assets/styles/extensions/comments.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/comments.scss
@@ -5,6 +5,6 @@
 @media only print {
   hypothesis-sidebar,
   div.utterances {
-    display: none !important;
+    display: none;
   }
 }

--- a/src/sphinx_book_theme/assets/styles/extensions/comments.scss
+++ b/src/sphinx_book_theme/assets/styles/extensions/comments.scss
@@ -1,7 +1,7 @@
 /**
  * Comment JavaScript libraries
   * Libraries supported here are:
-  * - Hypothesis.is : https://web.hypothes.is/
+  * - Hypothes.is : https://web.hypothes.is/
   * - Utteranc.es : https://utteranc.es/
   */
 // In general we want to hide any comment libraries on print

--- a/src/sphinx_book_theme/assets/styles/index.scss
+++ b/src/sphinx_book_theme/assets/styles/index.scss
@@ -44,6 +44,7 @@
 
 // Content blocks from Sphinx extensions
 @import "extensions/ablog";
+@import "extensions/comments";
 @import "extensions/myst-nb";
 @import "extensions/sphinx-tabs";
 @import "extensions/thebe";


### PR DESCRIPTION
This adds some minor CSS rules for comments libraries, to ensure they don't show up when printing a page.