### PR TITLE
STYLE: Search color highlighting in-line with Jupyter orange

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
     # - someurl: dummy url
     # - mailto: fails test but works for people
     # - pathto(: because the pydata theme packages invalid HTML w/ this in it
+    # - mybinder.org: because Binder sometimes incorrectly doesn't respond
     - name: Check for broken links
       id: lychee
       uses: lycheeverse/lychee-action@v1.3.2
@@ -110,6 +111,7 @@ jobs:
           --exclude 'someurl'
           --exclude 'mailto:docutils-develop'
           --exclude 'pathto\('
+          --exclude 'mybinder.org'
 
     - name: Audit with Lighthouse
       uses: treosh/lighthouse-ci-action@9.3.0

--- a/src/sphinx_book_theme/assets/styles/pages/_search.scss
+++ b/src/sphinx_book_theme/assets/styles/pages/_search.scss
@@ -16,6 +16,16 @@ div#search-results > h2 {
   margin-top: 0;
 }
 
+// HACK: For some reason there are two search results sections created.
+// This removes the first one.
+div#search-results {
+  > h2:first-of-type,
+  > p.search-summary:first-of-type,
+  > ul.search:first-of-type {
+    display: none;
+  }
+}
+
 // The results of a search
 ul.search {
   margin: 0;
@@ -24,5 +34,15 @@ ul.search {
   li {
     background-image: none;
     padding: 0;
+    margin-bottom: 2em;
+
+    p.context {
+      margin: 0;
+    }
+
+    // Highlighted search items are a slightly lighter version of Jupyter orange
+    span.highlighted {
+      background-color: #f3772642;
+    }
   }
 }

--- a/src/sphinx_book_theme/assets/styles/pages/_search.scss
+++ b/src/sphinx_book_theme/assets/styles/pages/_search.scss
@@ -16,16 +16,6 @@ div#search-results > h2 {
   margin-top: 0;
 }
 
-// HACK: For some reason there are two search results sections created.
-// This removes the first one.
-div#search-results {
-  > h2:first-of-type,
-  > p.search-summary:first-of-type,
-  > ul.search:first-of-type {
-    display: none;
-  }
-}
-
 // The results of a search
 ul.search {
   margin: 0;


### PR DESCRIPTION
This just updates the theme's highlighting color to use a light version of "Jupyter orange", so it's less jarring than the bright yellow default highlighting color