### PR TITLE
RLS: v0.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2 -- 2022-03-28
+
+Two patch releases fixed two bugs for figure content in the margin.
+
 ## v0.3.0 - 2022-03-25
 
 This is a significant change in the HTML and CSS of the site, with the goal of making it more standardized and robust. There are several design tweaks that have been made. Here is a short overview:

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util import logging
 from .header_buttons import prep_header_buttons, add_header_buttons
 from .header_buttons.launch import add_launch_buttons
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 """sphinx-book-theme version"""
 
 SPHINX_LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Minor release for another margin bugfix.

Also updated our pre-commit pin for black because we ran into a bug with the version we were using (ref: https://github.com/psf/black/issues/2634)