### PR TITLE
FIX: Escape colon in JupyterHub link to repo

### DIFF
--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -118,9 +118,10 @@ def add_launch_buttons(
         )
 
     if jupyterhub_url:
+        repo_esc = repo_url.replace(':', '%3A')
         url = (
             f"{jupyterhub_url}/hub/user-redirect/git-pull?"
-            f"repo={repo_url}&urlpath={ui_pre}/{repo}/{path_rel_repo}&branch={branch}"
+            f"repo={repo_esc}&urlpath={ui_pre}/{repo}/{path_rel_repo}&branch={branch}"
         )
         launch_buttons_list.append(
             {

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any, Dict, Optional
+from urllib.parse import urlencode
 
 from docutils.nodes import document
 from sphinx.application import Sphinx
@@ -118,11 +119,11 @@ def add_launch_buttons(
         )
 
     if jupyterhub_url:
-        repo_esc = repo_url.replace(":", "%3A")
-        url = (
-            f"{jupyterhub_url}/hub/user-redirect/git-pull?"
-            f"repo={repo_esc}&urlpath={ui_pre}/{repo}/{path_rel_repo}&branch={branch}"
-        )
+        url_params = urlencode(dict(
+            repo=repo_url,
+            urlpath=f"{ui_pre}/{repo}/{path_rel_repo}",
+            branch=branch), safe="/")
+        url = f"{jupyterhub_url}/hub/user-redirect/git-pull?{url_params}"
         launch_buttons_list.append(
             {
                 "type": "link",

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -119,10 +119,12 @@ def add_launch_buttons(
         )
 
     if jupyterhub_url:
-        url_params = urlencode(dict(
-            repo=repo_url,
-            urlpath=f"{ui_pre}/{repo}/{path_rel_repo}",
-            branch=branch), safe="/")
+        url_params = urlencode(
+            dict(
+                repo=repo_url, urlpath=f"{ui_pre}/{repo}/{path_rel_repo}", branch=branch
+            ),
+            safe="/",
+        )
         url = f"{jupyterhub_url}/hub/user-redirect/git-pull?{url_params}"
         launch_buttons_list.append(
             {

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -118,7 +118,7 @@ def add_launch_buttons(
         )
 
     if jupyterhub_url:
-        repo_esc = repo_url.replace(':', '%3A')
+        repo_esc = repo_url.replace(":", "%3A")
         url = (
             f"{jupyterhub_url}/hub/user-redirect/git-pull?"
             f"repo={repo_esc}&urlpath={ui_pre}/{repo}/{path_rel_repo}&branch={branch}"

--- a/tests/test_build/build__header-article.html
+++ b/tests/test_build/build__header-article.html
@@ -27,7 +27,7 @@
        </a>
       </li>
       <li>
-       <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
+       <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
         <span class="headerbtn__icon-container">
          <img src="../_static/images/logo_jupyterhub.svg"/>
         </span>

--- a/tests/test_build/test_header_launchbtns.html
+++ b/tests/test_build/test_header_launchbtns.html
@@ -16,7 +16,7 @@
     </a>
    </li>
    <li>
-    <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
+    <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
      <span class="headerbtn__icon-container">
       <img src="../_static/images/logo_jupyterhub.svg"/>
      </span>

--- a/tests/test_build/test_topbar_launchbtns.html
+++ b/tests/test_build/test_topbar_launchbtns.html
@@ -16,7 +16,7 @@
     </a>
    </li>
    <li>
-    <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
+    <a class="headerbtn" data-placement="left" data-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" title="Launch on JupyterHub">
      <span class="headerbtn__icon-container">
       <img src="../_static/images/logo_jupyterhub.svg"/>
      </span>


### PR DESCRIPTION
I've run into a problem using The Littlest JupyterHub with current
`sphinx-book-theme`. At the moment the generated URLs for JupyterHub are
of form:

```
<hub-url>/hub/user-redirect/git-pull?repo=https://<repo>&urlpath=tree/<nb_fname>
```

These work fine on a modern Kubernetes JupyterHub, I guess because of
a recent version of JupyterHub responding to the query.

But, on current The Littlest JupyterHub, still on JupyterHub 1.5.0, this
causes Nbgitpuller to stall if the user is not already logged in, with
log messages of form:

```
Disallowing redirect outside JupyterHub:
'/hub/user-redirect/git-pull?repo=https://github.com/<repo>&urlpath=tree/<nb_fname>'.
```

Once logged in, retrying the same link works correctly.

This can be fixed by escaping the `:` in the Nbgitpuller URL with a
`%3A`, in this PR.