### PR TITLE
Prototype landing page edits

### DIFF
--- a/docs/customize/index.md
+++ b/docs/customize/index.md
@@ -9,6 +9,8 @@ The following options are available via `html_theme_options`
 ```{list-table}
 :widths: 10 5 40
 :header-rows: 1
+:class: full-width
+
 * - Key
   - Type
   - Description

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 title: The Sphinx Book Theme
+theme:
+  collapse_sidebar: true
+  full_width: true
 ---
 
 ::::{grid}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ doc = [
     "numpy",
     "matplotlib",
     "numpydoc",
-    "myst-nb~=0.13",
+    "myst-nb~=0.13.2",
     "nbclient",
     "pandas",
     "plotly",

--- a/src/sphinx_book_theme/assets/styles/sections/_article.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_article.scss
@@ -8,7 +8,7 @@ body {
 
 #main-content,
 #print-main-content {
-  transition: padding $animation-time ease-out;
+  transition: all $animation-time ease-out;
   padding-top: 1.5em;
 }
 

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebars-toggle.scss
@@ -18,8 +18,18 @@ input#__navigation {
 
       // When we hide the sidebar on widescreen, add some padding to content
       & ~ .container-xl #main-content {
-        padding-left: 4rem;
+        padding-left: 7rem;
         padding-right: 4rem;
+
+        // At full-width, there is no margin so add some extra padding
+        &.full-width {
+          padding-left: 4rem;
+          padding-right: 4rem;
+          margin: auto;
+          // Set the maximum width to an L container in bootstrap
+          // ref: https://getbootstrap.com/docs/5.0/layout/containers/
+          max-width: 960px;
+        }
       }
     }
   }

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -6,7 +6,8 @@
 
 {% block content %}
 <!-- Checkboxes to toggle the left sidebar -->
-<input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation" aria-label="Toggle navigation sidebar">
+{% set checked=" checked" if collapse_sidebar == True else "" %}
+<input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation" aria-label="Toggle navigation sidebar"{{ checked }}>
 <label class="overlay overlay-navbar" for="__navigation">
     <div class="visually-hidden">Toggle navigation sidebar</div>
 </label>
@@ -77,7 +78,8 @@
                     </div>
                 </div>
             </div>
-            <main id="main-content" role="main">
+            {% set full_width = ' class="full-width"' if (full_width == True) else '' %}
+            <main id="main-content" role="main"{{ full_width }}>
                 {{ super() }}
             </main>
             <footer class="footer-article noprint">

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/theme.conf
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/theme.conf
@@ -15,9 +15,9 @@ repository_branch =
 launch_buttons = {}
 home_page_in_toc = False
 logo_only =
-# DEPRECATE after a few release cycles
-navbar_footer_text =
 show_navbar_depth = 1
+collapse_sidebar = false
+full_width = false
 toc_title = Contents
 extra_navbar = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
 extra_footer =
@@ -26,4 +26,6 @@ use_fullscreen_button = True
 # Repository buttons
 use_issues_button = False
 use_repository_button = False
+# DEPRECATE after a few release cycles
+navbar_footer_text =
 # Note: We also inherit use_edit_page_button from the PyData theme


### PR DESCRIPTION
This is a prototype to play around with better "landing page" style structure, using page-level metadata. Here are the major changes:

- **Adds page-level metadata**. This has a structure like the following (meant to be put in the markdown file's YAML metadata):
  
  ```yaml
  theme:
    collapse_sidebar: true
    full_width: true
  ```
  
  If that is in the page metadata it will either collapse the sidebar by default, or make the page full-width by default.
  In addition, there are now global configs for this as well.
- **Updates the padding on full-width + collapsed_sidebar**. If the article is set as full-width, and the sidebar is collapsed, then we add extra padding and center the content, so that it looks more like a typical "landing page". This should hopefully make it more suitable 

ref: #162 (I think this is a step in that direction but may not totally address it)