### PR TITLE
MAINT: Fix myst-nb pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ doc = [
     "numpy",
     "matplotlib",
     "numpydoc",
-    "myst-nb~=0.13",
+    "myst-nb~=0.13.2",
     "nbclient",
     "pandas",
     "plotly",
@@ -71,7 +71,7 @@ doc = [
 test = [
     "beautifulsoup4>=4.6.1,<5",
     "coverage",
-    "myst_nb~=0.13",
+    "myst-nb~=0.13.2",
     "pytest~=6.0.1",
     "pytest-cov",
     "pytest-regressions~=2.0.1",


### PR DESCRIPTION
This fixes the myst-nb pinning in our docs and test suite, since a new release was creating problems and these weren't properly pinned.