### PR TITLE
IntersectionObserver at 1/3 screen

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This is a short overview of the general architecture and structure of the repository, to help you orient yourself.
 
-This theme uses [sphinx-theme-builder](https://sphinx-theme-builder.readthedocs.io/en/latest/) as its build backend, and follows the [filesystem layout](https://sphinx-theme-builder.readthedocs.io/en/latest/reference/filesystem-layout/) recommended by it.
+This theme uses [sphinx-theme-builder](https://sphinx-theme-builder.readthedocs.io/en/latest/) as its build backend, and follows the [filesystem layout](https://sphinx-theme-builder.readthedocs.io/en/latest/filesystem-layout/) recommended by it.
 See below for some more specific sections
 
 ```{contents}

--- a/src/sphinx_book_theme/assets/scripts/index.js
+++ b/src/sphinx_book_theme/assets/scripts/index.js
@@ -132,7 +132,7 @@ var initTocHide = () => {
 
   // Set up the intersection observer to watch all margin content
   let options = {
-    // This makes the event trigger when the top of an item is mid-way
+    // Trigger callback when the top of a margin item is 1/3 up the screen
     rootMargin: "0px 0px -33% 0px",
   };
   let tocObserver = new IntersectionObserver(hideTocCallback, options);

--- a/src/sphinx_book_theme/assets/scripts/index.js
+++ b/src/sphinx_book_theme/assets/scripts/index.js
@@ -131,7 +131,11 @@ var initTocHide = () => {
   };
 
   // Set up the intersection observer to watch all margin content
-  let tocObserver = new IntersectionObserver(hideTocCallback);
+  let options = {
+    // This makes the event trigger when the top of an item is mid-way
+    rootMargin: "0px 0px -33% 0px",
+  };
+  let tocObserver = new IntersectionObserver(hideTocCallback, options);
   // TODO: deprecate popout after v0.5.0
   const selectorClasses = [
     "marginnote",


### PR DESCRIPTION
This adjusts our IntersectionObserver so that the Table of Contents section hides itself when margin content is 33% up from the bottom of the screen, rather than as soon as it shows up on the screen at all.

This should hopefully be a nice balance between "it doesn't hide soon enough and so blocks content" and "it hides too aggressively / quickly" as reported in:

- https://github.com/executablebooks/jupyter-book/issues/1729

I chose 33% as it seemed to be a reasonable  point at which a reader might actually _want_ to look at some margin content.

cc @spring-haru - think this is a nice compromise?

closes https://github.com/executablebooks/jupyter-book/issues/1729