### PR TITLE
Fix: use asset types to avoid breaking sorting

### DIFF
--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -104,16 +104,11 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
             ix = asset_context.index(asset)
         except ValueError:
             continue
-
-        asset_hash = _gen_hash(asset_source_path)
+        asset_obj = asset_context[ix]
 
         # Regenerate the asset type with the hashed filename
-        asset_obj = asset_context[ix]
-        asset_context[ix] = type(asset_obj)(
-            filename=f"{asset_sphinx_link}?digest={asset_hash}",
-            priority=asset_obj.priority,
-            **asset_obj.attributes,
-        )
+        asset_hash = _gen_hash(asset_source_path)
+        asset_obj.filename = f"{asset_sphinx_link}?digest={asset_hash}"
 
 
 def hash_html_assets(app, pagename, templatename, context, doctree):

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -107,6 +107,7 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
 
         asset_hash = _gen_hash(asset_source_path)
 
+        # Regenerate the asset type with the hashed filename
         asset_obj = asset_context[ix]
         asset_context[ix] = type(asset_obj)(
             filename=f"{asset_sphinx_link}?digest={asset_hash}",

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -90,28 +90,32 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
                 f"Asset {asset_source_path} does not exist, not linking."
             )
             continue
-            
-        asset_hash = _gen_hash(asset_source_path)
-        new_asset_sphinx_link = f"{asset_sphinx_link}?digest={asset_hash}"
         
         # CSS assets are stored in css_files, JS assets in script_files
         if asset.endswith(".css"):
-            new_asset = Stylesheet(new_asset_sphinx_link)
             asset_context = context.get("css_files", [])
         elif asset.endswith(".js"):
-            new_asset = JavaScript(new_asset_sphinx_link)
             asset_context = context.get("js_files", [])
         else:
             SPHINX_LOGGER.warn(
                 f"Unrecognised asset type, not hashing."
             )
+            continue
             
         # Find this asset in context, and update it to include the digest
         try:
             ix = asset_context.index(asset)
         except ValueError:
             continue
-        asset_context[ix] = new_asset
+
+        asset_hash = _gen_hash(asset_source_path)
+
+        asset_obj = asset_context[ix]
+        asset_context[ix] = type(asset_obj)(
+            filename=f"{asset_sphinx_link}?digest={asset_hash}",
+            priority=asset_obj.priority,
+            **asset_obj.attributes
+        )
 
 
 def hash_html_assets(app, pagename, templatename, context, doctree):

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -87,17 +87,13 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
         elif asset.endswith(".js"):
             asset_context = context.get("js_files", [])
         else:
-            SPHINX_LOGGER.warn(f"Unrecognised asset type: {asset}. Not hashing.")
-            continue
+            raise ValueError(f"Unrecognised asset type: {asset}.")
 
         # Define paths to the original asset file, and its linked file in Sphinx
         asset_sphinx_link = f"_static/{asset}"
         asset_source_path = theme_static / asset
         if not asset_source_path.exists():
-            SPHINX_LOGGER.warn(
-                f"Asset {asset_source_path} does not exist, not linking."
-            )
-            continue
+            raise FileNotFoundError(f"Asset {asset_source_path} does not exist.")
 
         # Find this asset in context, and update it to include the digest
         try:

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -81,7 +81,8 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
     """
     for asset in assets:
         # CSS assets are stored in css_files, JS assets in script_files
-        # Use the html context list of assets so we replace it in-place and retain ordering
+        # Use the html context list of assets so we replace it in-place
+        # and retain ordering
         if asset.endswith(".css"):
             asset_context = context.get("css_files", [])
         elif asset.endswith(".js"):

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -69,9 +69,6 @@ def _gen_hash(path: str) -> str:
     return hashlib.sha1(path.read_bytes()).hexdigest()
 
 
-from sphinx.builders.html import JavaScript, Stylesheet
-
-
 def hash_assets_for_files(assets: list, theme_static: Path, context):
     """Generate a hash for assets, and append to its entry in context.
 

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from docutils.parsers.rst.directives.body import Sidebar
 from docutils import nodes as docutil_nodes
 from sphinx.application import Sphinx
-from sphinx.builders.html import JavaScript, Stylesheet
 from sphinx.locale import get_translation
 from sphinx.util import logging
 

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -90,9 +90,7 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
         elif asset.endswith(".js"):
             asset_context = context.get("js_files", [])
         else:
-            SPHINX_LOGGER.warn(
-                f"Unrecognised asset type, not hashing."
-            )
+            SPHINX_LOGGER.warn(f"Unrecognised asset type, not hashing.")
             continue
 
         # Define paths to the original asset file, and its linked file in Sphinx
@@ -116,7 +114,7 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
         asset_context[ix] = type(asset_obj)(
             filename=f"{asset_sphinx_link}?digest={asset_hash}",
             priority=asset_obj.priority,
-            **asset_obj.attributes
+            **asset_obj.attributes,
         )
 
 

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -81,6 +81,7 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
     """
     for asset in assets:
         # CSS assets are stored in css_files, JS assets in script_files
+        # Use the html context list of assets so we replace it in-place and retain ordering
         if asset.endswith(".css"):
             asset_context = context.get("css_files", [])
         elif asset.endswith(".js"):

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -87,7 +87,7 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
         elif asset.endswith(".js"):
             asset_context = context.get("js_files", [])
         else:
-            SPHINX_LOGGER.warn(f"Unrecognised asset type, not hashing.")
+            SPHINX_LOGGER.warn(f"Unrecognised asset type: {asset}. Not hashing.")
             continue
 
         # Define paths to the original asset file, and its linked file in Sphinx


### PR DESCRIPTION
Currently, we break the priority sorting of assets by writing strings back to the asset lists. This PR ensures that the asset instance types (Stylesheet,  JavaScript) are used with a default priority to avoid breaking things.

I don't love this implementation, but it's probably good enough™