### PR TITLE
Remove last-child zero-margin on <dd>'s

### DIFF
--- a/src/sphinx_book_theme/assets/styles/content/_field-lists.scss
+++ b/src/sphinx_book_theme/assets/styles/content/_field-lists.scss
@@ -7,10 +7,4 @@ dl.field-list {
   & dd {
     margin-left: 1.5em;
   }
-  & dd:not(:last-child) {
-    margin-bottom: 0px;
-    p:last-child {
-      margin-bottom: 0px;
-    }
-  }
 }


### PR DESCRIPTION
Hi there :wave: 

The style for dl's seems to originate from https://github.com/executablebooks/sphinx-book-theme/pull/191 and following some refactors, I don't see any changes or reasons why this margin seems so off.

I suppose it's unintentional that a definition is closer to the succeeding term than the term its actually a definition for?

Before:

![image](https://user-images.githubusercontent.com/374612/178762534-2c6e4f64-ba3d-4da6-8824-2d46b184053b.png)

After:

![image](https://user-images.githubusercontent.com/374612/178762680-f3850b07-50e7-41ae-89d1-f53b94e7d5b4.png)
