### PR TITLE
MAINT: remove incorrect comment from sphinx pin.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
     "nbclient",
     "pandas",
     "plotly",
-    "sphinx~=4.0",  # Force Sphinx to be the latest version
+    "sphinx~=4.0",
     "sphinx-design",
     "sphinx-examples",
     "sphinx-copybutton",


### PR DESCRIPTION
The comment here was out-of-date (sphinx 5 has been released)
which made it unclear whether the pin was intentional or an
error. From the discussion in gh-583, it's now clear the pin
is intentional, so removing the comment for clarity.

Alternatively, the comment could be updated in a way that won't
be obsoleted by future sphinx releases - wording suggestions
welcome.

Closes #583 