### PR TITLE
Add skip to main content link

### DIFF
--- a/src/sphinx_book_theme/assets/styles/components/_buttons.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_buttons.scss
@@ -117,3 +117,18 @@ div.header-article-main {
     display: none;
   }
 }
+
+.skip-link {
+  display: block;
+  left: -999px;
+  position: absolute;
+  top: -999px;
+
+  &:focus {
+    left: 0;
+    padding: 0.2rem 0.3rem;
+    position: relative;
+    top: 0;
+    z-index: 999999;
+  }
+}

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/layout.html
@@ -15,6 +15,8 @@
 <label class="overlay overlay-pagetoc" for="__page-toc">
     <div class="visually-hidden">Toggle in-page Table of Contents</div>
 </label>
+<!-- Skip to main content -->
+<a href="#main-content" class="skip-link">Jump to main content</a>
 <!-- Headers at the top -->
 <div class="announcement header-item noprint">
     {%- include "sections/announcement.html" -%}


### PR DESCRIPTION
Add a simple jump to main content link on top of the page (only visible when you first press tab) so users can skip the left navigation

![image](https://user-images.githubusercontent.com/20623084/192817558-837fc70e-f651-49e3-8ddb-9b7689298e0d.png)

