### PR TITLE
Bump the version of pytest for compatibility with python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
     "beautifulsoup4>=4.6.1,<5",
     "coverage",
     "myst-nb~=0.13.2",
-    "pytest~=6.0.1",
+    "pytest~=6.2.5",
     "pytest-cov",
     "pytest-regressions~=2.0.1",
     "sphinx_thebe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ test = [
     "beautifulsoup4>=4.6.1,<5",
     "coverage",
     "myst-nb~=0.13.2",
-    "pytest~=6.2.5",
-    "pytest-cov",
+    "pytest~=7.1",
+    "pytest-cov~=3.0",
     "pytest-regressions~=2.0.1",
     "sphinx_thebe"
 ]


### PR DESCRIPTION
Pytest 6.2.5 is the first version that supports python 3.10: https://pytest.org/en/latest/changelog.html#pytest-6-2-5-2021-08-29