### PR TITLE
MAINT: Factor publish to pypi workflow into dedicated file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+# This will run every time a tag is created and pushed to the repository.
+# It calls our tests workflow via a `workflow_call`, and if tests pass
+# then it triggers our upload to PyPI for a new release.
+name: Publish to PyPI
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish:
+    name: publish
+    needs: [tests] # require tests to pass before deploy runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Build package
+        run: |
+          python -m pip install -U pip build
+          python -m build
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - 'v*'
   pull_request:
+  workflow_call:
 
 env:
   PY_COLORS: 1
@@ -105,28 +106,3 @@ jobs:
         temporaryPublicStorage: true
         uploadArtifacts: true
         runs: 5
-
-  publish:
-    name: Publish to PyPI
-    needs: [pre-commit, tests]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-
-      - name: Build package
-        run: |
-          python -m pip install -U pip build
-          python -m build
-
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
Currently we have a workflow embedded in `tests.yml` that is called only if a new release is made. However this shows us as "not run" in our test suite in github and messes with the passing tests condition.

This PR factors that out into a dedicated workflow file that is run on `publish` and _calls_ our test suite before running the publish command. That should mean the "Publish to PyPI" action never gets run unless we are publishing.

cc @AakashGfude this should make it easier to quickly see if the tests are happy in PRs