### PR TITLE
Enable JupyterHub launch button usage with GitLab

### DIFF
--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -15,7 +15,7 @@ from .header_buttons import prep_header_buttons, add_header_buttons
 from .header_buttons.launch import add_launch_buttons
 from ._transforms import HandleFootnoteTransform
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 """sphinx-book-theme version"""
 
 SPHINX_LOGGER = logging.getLogger(__name__)

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -196,7 +196,8 @@ def _split_repo_url(url):
         org, repo = end.split("/")[:2]
     else:
         SPHINX_LOGGER.warning(
-            "Currently only repositories on GitHub are supported for launch in Binder/JupterHub. "
+            "Currently only repositories on GitHub are supported for "
+            "launch in Binder/JupterHub. "
             "If you want to link to other servers "
             "make sure the repository name is the last part of the url."
         )

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -196,9 +196,12 @@ def _split_repo_url(url):
         org, repo = end.split("/")[:2]
     else:
         SPHINX_LOGGER.warning(
-            f"Currently Binder/JupyterHub repositories must be on GitHub, got {url}"
+            "Currently only repositories on GitHub are supported for launch in Binder/JupterHub. "
+            "If you want to link to other servers "
+            "make sure the repository name is the last part of the url."
         )
-        org = repo = None
+        org = None
+        repo = url.split("/")[-1]
     return org, repo
 
 


### PR DESCRIPTION
So far only GitHub repositories are supported to work with the JupyterHub launch button. This PR adds very little code that enables support for other servers as well such as GitLab as long as the repository name remains at the end of the repo url, i.e. https://examplegitlab.com/mygitlab/myrepo