### PR TITLE
DOCS: Minor typo correction

### DIFF
--- a/docs/launch.md
+++ b/docs/launch.md
@@ -13,7 +13,7 @@ html_theme_options = {
     ...
     "repository_url": "https://github.com/{your-docs-url}",
     "repository_branch": "{your-branch}",
-    "path_to_docs": "{path-relative-to-site-root},
+    "path_to_docs": "{path-relative-to-site-root}",
     ...
 }
 ```


### PR DESCRIPTION
There was an end-quote missing in the `docs/launch.md` file.