### PR TITLE
MAINT: Move dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Dependabot is creating a lot of noise for small patch changes in our PRs. This changes it to monthly instead of weekly.

I don't think this one is controversial so will self-merge in a few days if I don't hear any objections.