### PR TITLE
MAINT: Update pre-commit versions and fix minor bugs in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,16 @@ exclude: >
     (?x)^(
       \.vscode/settings\.json|
     )$
+
+# Fix the node version to avoid a GLIBC error
+# ref: https://stackoverflow.com/questions/71939099/bitbucket-pipeline-error-installing-pre-commit-ts-lint/71940852#71940852
+default_language_version:
+    node: 16.14.2
+
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     - id: check-toml
     - id: check-json
@@ -17,12 +23,12 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
     - id: black
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,7 +3,7 @@
 Thank you for being interested in contributing to the `sphinx-book-theme`! You
 are awesome ✨.
 
-This project follows the Executable Books Project [contribution guidelines](https://executablebooks.org/en/latest/contributing.html).
+This project follows the Executable Books Project [contribution guidelines](https://executablebooks.org/en/latest/contribute.html).
 It contains information about our conventions around coding style, pull request workflow, commit messages and more.
 
 The rest of these sections contain information about developing the `sphinx-book-theme` specifically.

--- a/docs/reference/special-theme-elements.md
+++ b/docs/reference/special-theme-elements.md
@@ -65,7 +65,7 @@ This is some markdown that should be shown at full width.
 
 Here's the Jupyter logo:
 
-![](https://raw.githubusercontent.com/adebar/awesome-jupyter/master/logo.png)
+![](https://raw.githubusercontent.com/adebar/awesome-jupyter/master/assets/logo.png)
 
 :::{note}
 Here's a full-width admonition!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ code_style = [
 doc = [
     "ablog~=0.10.13",
     "ipywidgets",
+    # 8.7.0 broke the `ipython3` lexer in Sphinx so we want to avoid it
+    "ipython!=8.7.0",
     "folium",
     "numpy",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,6 @@ code_style = [
 doc = [
     "ablog~=0.10.13",
     "ipywidgets",
-    # 8.7.0 broke the `ipython3` lexer in Sphinx so we want to avoid it
-    "ipython!=8.7.0",
     "folium",
     "numpy",
     "matplotlib",
@@ -77,7 +75,9 @@ test = [
     "pytest~=7.1",
     "pytest-cov>=3,<5",
     "pytest-regressions>=2.0.1,<2.5.0",
-    "sphinx_thebe"
+    "sphinx_thebe",
+    # 8.7.0 broke the `ipython3` lexer in Sphinx so we want to avoid it
+    "ipython!=8.7.0",
 ]
 
 [project.entry-points]


### PR DESCRIPTION
On systems that don't have the right version of GLIBC installed pre-commit will not work because of a missing dependency as described in this SO post:

- https://stackoverflow.com/questions/71939099/bitbucket-pipeline-error-installing-pre-commit-ts-lint/71940852#71940852

This fixes the version of node that is used so that this issue doesn't pop up, as per the guidelines in that issue.

It also avoids `ipython==8.7.0` in our tests to stop having a lexer bug that it introduced. 

I'll merge this one quickly so that we can fix pre-commit and get our tests passing.