### PR TITLE
[FIX] Use logo url as is to allow for web urls.

### DIFF
--- a/src/sphinx_book_theme/theme/sphinx_book_theme/components/sidebar-logo.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/components/sidebar-logo.html
@@ -5,7 +5,7 @@
         {% set logo_url=logo %}
       {% endif %}
       {% if logo_url %}
-      <img src="{{ pathto('_static/' + logo_url, 1) }}" class="logo" alt="logo">
+      <img src="{{ logo_url|e }}" class="logo" alt="logo">
       {% endif %}
       {% if docstitle and not theme_logo_only %}
       <h1 class="site-logo" id="site-title">{{ docstitle }}</h1>


### PR DESCRIPTION
`logo_url` can sometimes be a fully qualified URL starting in Sphinx 4.
Adding the `_static` prefix breaks logos that are URLs.
