### PR TITLE
RLS 1.0.0: (repeat) Fix a link and improve test reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,9 +58,9 @@ jobs:
       run: >
         pytest --durations=10 --cov=sphinx_book_theme --cov-report=xml --cov-report=term-missing
 
-    # Only check for broken links on pull requests so that we don't trigger rate limit blocks
+    # Only upload to codecov on pull requests so that we don't trigger rate limit blocks
     - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && github.repository == 'executablebooks/sphinx-book-theme && github.event_name == 'pull_request''
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && github.repository == 'executablebooks/sphinx-book-theme' && github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.1
       with:
         name: ebp-sbt-pytests-py3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,9 @@ jobs:
       run: >
         pytest --durations=10 --cov=sphinx_book_theme --cov-report=xml --cov-report=term-missing
 
+    # Only check for broken links on pull requests so that we don't trigger rate limit blocks
     - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && github.repository == 'executablebooks/sphinx-book-theme'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && github.repository == 'executablebooks/sphinx-book-theme && github.event_name == 'pull_request''
       uses: codecov/codecov-action@v3.1.1
       with:
         name: ebp-sbt-pytests-py3.7
@@ -84,7 +85,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[doc]
 
+    # Only check for broken links on pull requests so that we don't block releases
     - name: Check for broken links
+      if: github.event_name == 'pull_request'
       run: >
         sphinx-build -b linkcheck docs docs/_build/linkcheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,7 +329,7 @@ This updates to the latest PyData Sphinx Theme, which re-works some of the HTML 
 ## v0.0.36 2020-08-25
 
 👌 IMPROVED: The main theme change in this release, is the addition of CSS styling for definition lists, including those created by [sphinx.ext.autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html).
-See [Definition and Field Lists](https://sphinx-book-theme.readthedocs.io/en/stable/reference/kitchen-sink/lists-and-tables.html), and the [Python API documentation](https://sphinx-book-theme.readthedocs.io/en/latest/reference/kitchen-sink/api.html).
+See [Definition and Field Lists](https://sphinx-book-theme.readthedocs.io/en/latest/reference/kitchen-sink/lists.html), and the [Python API documentation](https://sphinx-book-theme.readthedocs.io/en/latest/reference/kitchen-sink/api.html).
 
 🔧 MAINTENANCE: Under the hood, there has also been work undertaken to improve the development environment for working with the package. Thanks to [@pradyunsg](https://github.com/pradyunsg).
 


### PR DESCRIPTION
We got bitten by a codecov rate limit bug (cc @AakashGfude you mentioned this in slack too) and then got bitten by a linkcheck that broke only _after_ the release had been made. I don't think we want to block release actions on broken links, so this just runs the codecov + the linkcheck jobs on the `pull_request` event, which means it won't trigger on the `release` event.