### PR TITLE
Fix typos in navbar documentation

### DIFF
--- a/docs/sections/header.md
+++ b/docs/sections/header.md
@@ -14,7 +14,7 @@ There are three configuration options you can use in `html_theme_options`:
 
 **`navbar_end`**: Adds components to the end of the header. **Moved to the sizebar on mobile**. Use this for extra social links or buttons.
 
-## An eample
+## An example
 
 For example, you can add a button to the header like so:
 

--- a/docs/sections/header.md
+++ b/docs/sections/header.md
@@ -1,7 +1,7 @@
 # Header and navbar
 
 By default, this theme does not contain any header content, it only has a sidebar and a main content window.
-However, you may [use the PyData Sphinx Theme's header configuraiton](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#header-navigation-bar) to add your own header components.
+However, you may [use the PyData Sphinx Theme's header configuration](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#header-navigation-bar) to add your own header components.
 If any of this configuration is set, then your header will show at the top of the page.
 
 ## Add components to the header navbar


### PR DESCRIPTION
Mini PR to fix two typos I found whilst reading the header and navbar documentation.

Edit: seems like the docs build is failing - will take a look (The build succeds locally)

https://sphinx-book-theme.readthedocs.io/en/stable/sections/header.html