### PR TITLE
add support for gitlab issue button

### DIFF
--- a/src/sphinx_book_theme/header_buttons/source.py
+++ b/src/sphinx_book_theme/header_buttons/source.py
@@ -88,9 +88,9 @@ def add_source_buttons(app, pagename, templatename, context, doctree):
             repo_url, provider = get_repo_url(context)
             if provider in ("github", "gitlab"):
                 if provider == "github":
-                    url = f"{repo_url}/issues/new?title=Issue%20on%20page%20%2F{context['pagename']}.html&body=Your%20issue%20content%20here.",  # noqa: E501
+                    url = f"{repo_url}/issues/new?title=Issue%20on%20page%20%2F{context['pagename']}.html&body=Your%20issue%20content%20here."  # noqa: E501
                 elif provider == "gitlab":
-                    url = f"{repo_url}/-/issues/new?issue[title]=Issue%20on%20page%20%2F{context['pagename']}.html&issue[description]=Your%20issue%20content%20here.",  # noqa: E501
+                    url = f"{repo_url}/-/issues/new?issue[title]=Issue%20on%20page%20%2F{context['pagename']}.html&issue[description]=Your%20issue%20content%20here."  # noqa: E501
                 repo_buttons.append(
                     {
                         "type": "link",

--- a/src/sphinx_book_theme/header_buttons/source.py
+++ b/src/sphinx_book_theme/header_buttons/source.py
@@ -86,19 +86,23 @@ def add_source_buttons(app, pagename, templatename, context, doctree):
 
         if opts.get("use_issues_button"):
             repo_url, provider = get_repo_url(context)
-            if provider != "github":
-                LOGGER.warning(f"Open issue button not yet supported for {provider}")
-            else:
+            if provider in ("github", "gitlab"):
+                if provider == "github":
+                    url = f"{repo_url}/issues/new?title=Issue%20on%20page%20%2F{context['pagename']}.html&body=Your%20issue%20content%20here.",  # noqa: E501
+                elif provider == "gitlab":
+                    url = f"{repo_url}/-/issues/new?issue[title]=Issue%20on%20page%20%2F{context['pagename']}.html&issue[description]=Your%20issue%20content%20here.",  # noqa: E501
                 repo_buttons.append(
                     {
                         "type": "link",
-                        "url": f"{repo_url}/issues/new?title=Issue%20on%20page%20%2F{context['pagename']}.html&body=Your%20issue%20content%20here.",  # noqa: E501
+                        "url": url,
                         "text": translation("Open issue"),
                         "tooltip": translation("Open an issue"),
                         "icon": "fas fa-lightbulb",
                         "label": "source-issues-button",
                     }
                 )
+            else:
+                LOGGER.warning(f"Open issue button not yet supported for {provider}")
 
         # If we have multiple repo buttons enabled, add a group, otherwise just 1 button
         if len(repo_buttons) > 1:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -215,7 +215,7 @@ def test_header_repository_buttons(
 def test_source_button_url(sphinx_build_factory, file_regression, provider, repo):
     """Test that source button URLs are properly constructed."""
     # All buttons on
-    use_issues = "github.com" in repo
+    use_issues = "github.com" in repo or "gitlab.com" in repo or provider == "gitlab"
     confoverrides = {
         "html_theme_options": {
             "repository_url": repo,

--- a/tests/test_build/header__source-buttons--gitlab.html
+++ b/tests/test_build/header__source-buttons--gitlab.html
@@ -4,3 +4,5 @@ https://gitlab.com/gitlab-org/gitlab/-/blob/main/section1/ntbk.ipynb
 <i class="fas fa-code"></i>
 https://gitlab.com/gitlab-org/gitlab/-/edit/main/section1/ntbk.ipynb
 <i class="fas fa-pencil-alt"></i>
+https://gitlab.com/gitlab-org/gitlab/-/issues/new?issue[title]=Issue%20on%20page%20%2Fsection1/ntbk.html&issue[description]=Your%20issue%20content%20here.
+<i class="fas fa-lightbulb"></i>

--- a/tests/test_build/header__source-buttons--gitlab_manual.html
+++ b/tests/test_build/header__source-buttons--gitlab_manual.html
@@ -4,3 +4,5 @@ https://mywebsite.com/gitlab/gitlab-org/gitlab/-/blob/main/section1/ntbk.ipynb
 <i class="fas fa-code"></i>
 https://mywebsite.com/gitlab/gitlab-org/gitlab/-/edit/main/section1/ntbk.ipynb
 <i class="fas fa-pencil-alt"></i>
+https://mywebsite.com/gitlab/gitlab-org/gitlab/-/issues/new?issue[title]=Issue%20on%20page%20%2Fsection1/ntbk.html&issue[description]=Your%20issue%20content%20here.
+<i class="fas fa-lightbulb"></i>


### PR DESCRIPTION
Source for confirming that the format is correct: https://docs.gitlab.com/ee/user/project/issues/create_issues.html#using-a-url-with-prefilled-values