### PR TITLE
FIX set bd-docs-nav as a class attribute instead of an id to restore compat with pydata-sphinx-theme JS

### DIFF
--- a/src/sphinx_book_theme/theme/sphinx_book_theme/components/sbt-sidebar-nav.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/components/sbt-sidebar-nav.html
@@ -1,4 +1,4 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main">
+<nav class="bd-links bd-docs-nav" aria-label="Main">
     <div class="bd-toc-item navbar-nav active">
         {% if theme_home_page_in_toc == True %}
         {#- This mimicks the pydata theme list style so we can append an extra item at the top #}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -91,7 +91,7 @@ def test_build_book(sphinx_build_factory, file_regression):
     # Navigation entries
     if sphinx_build.software_versions == ".sphinx4":
         # Sphinx 4 adds some aria labeling that isn't in sphinx3, so just test sphinx4
-        sidebar = index_html.find(attrs={"id": "bd-docs-nav"})
+        sidebar = index_html.find(attrs={"class": "bd-docs-nav"})
         file_regression.check(
             sidebar.prettify(),
             basename="build__sidebar-primary__nav",
@@ -101,7 +101,7 @@ def test_build_book(sphinx_build_factory, file_regression):
 
     # Check navbar numbering
     sidebar_ntbk = sphinx_build.html_tree("section1", "ntbk.html").find(
-        "nav", id="bd-docs-nav"
+        "nav", attrs={"class": "bd-docs-nav"}
     )
     # Pages and sub-pages should be numbered
     assert "1. Page 1" in str(sidebar_ntbk)
@@ -146,7 +146,9 @@ def test_navbar_options_home_page_in_toc(sphinx_build_factory):
     ).build(
         assert_pass=True
     )  # type: SphinxBuild
-    navbar = sphinx_build.html_tree("index.html").find("nav", id="bd-docs-nav")
+    navbar = sphinx_build.html_tree("index.html").find(
+        "nav", attrs={"class": "bd-docs-nav"}
+    )
     # double checks if the master_doc has the current class
     li = navbar.find("li", attrs={"class": "current"})
     assert "Index with code in title" in str(li)


### PR DESCRIPTION
This is a partial fix for #541.

It makes the `scrollToActive` function from `pydata-sphinx-theme.js` work as expected on jupyter-book rendered HTML.

However, this function does not save the collapsed state of other sections which make the "scroll to saved location" a bit weird/broken at times.

Still, it's already much better than the current state.