### PR TITLE
Make article width take up whole page in absence of secondary sidebar

### DIFF
--- a/src/sphinx_book_theme/assets/styles/sections/_article-container.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_article-container.scss
@@ -1,10 +1,13 @@
 .bd-main .bd-content .bd-article-container {
   // Re-adjust padding defaults to be flush on the top and right
   padding: 0rem;
-
   // Unset overflow x so that sticky: top works for the article header
   overflow-x: unset;
-  min-width: 0; // prevent from overflowing the flex container
+  // prevent from overflowing the flex container
+  min-width: 0;
+  // keep article at reasonable width in absence of sidebar
+  max-width: calc(100% - var(--pst-sidebar-secondary));
+
   .bd-article {
     padding-right: 2rem;
     padding-left: 2rem;

--- a/src/sphinx_book_theme/assets/styles/sections/_article.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_article.scss
@@ -1,3 +1,4 @@
-.bd-main {
-  flex-grow: 0;
+.bd-main .bd-content {
+  // make article container left aligned in absence of sidebar
+  justify-content: left;
 }


### PR DESCRIPTION
Fixes #736

<table>
<tr>
<tr>
<td>before:
<td><img width="1462" alt="image" src="https://github.com/executablebooks/sphinx-book-theme/assets/291575/5969d462-1131-4607-8321-16bd98b08055">
<tr>
<tr>
<td>after:
<td><img width="1462" alt="image" src="https://github.com/executablebooks/sphinx-book-theme/assets/291575/6ad74ae8-9aa6-458c-83fc-930410b4dfaa">
</table>