### PR TITLE
FIX: Correctly disappear search button icon on wide screens

### DIFF
--- a/src/sphinx_book_theme/assets/styles/components/_search.scss
+++ b/src/sphinx_book_theme/assets/styles/components/_search.scss
@@ -24,7 +24,7 @@
 // Rules to switch off visibility of the field button and the header button
 @media (min-width: $breakpoint-lg) {
   .search-button {
-    display: none;
+    display: none !important;
   }
 
   .search-button-field {


### PR DESCRIPTION
Fixes a CSS override that would cause the search button icon to appear even on wide screens