### PR TITLE
Fix builds on Windows and docs errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,9 @@ jobs:
         sphinx: ["~=5.0","~=6.0","~=7.0"]
         include:
         - os: windows-latest
-          python-version: 3.x
+          # Python 3.12 is broken on windows builds until the following PR is released:
+          # https://github.com/pradyunsg/sphinx-theme-builder/pull/47
+          python-version: 3.11
           # Windows pulling in dependencies fails
           experimental: true
         - os: macos-latest

--- a/docs/content/notebooks.md
+++ b/docs/content/notebooks.md
@@ -223,13 +223,15 @@ import folium
 m = folium.Map(
     location=[45.372, -121.6972],
     zoom_start=12,
-    tiles='Stamen Terrain'
+    tiles='Stamen Terrain',
+    attr="Placeholder attr"
 )
 
 folium.Marker(
     location=[45.3288, -121.6625],
     popup='Mt. Hood Meadows',
-    icon=folium.Icon(icon='cloud')
+    icon=folium.Icon(icon='cloud'),
+    attr="Placeholder attr"
 ).add_to(m)
 
 folium.Marker(
@@ -241,7 +243,8 @@ folium.Marker(
 folium.Marker(
     location=[45.3300, -121.6823],
     popup='Some Other Location',
-    icon=folium.Icon(color='red', icon='info-sign')
+    icon=folium.Icon(color='red', icon='info-sign'),
+    attr="Placeholder attr"
 ).add_to(m)
 
 

--- a/docs/reference/notebooks.md
+++ b/docs/reference/notebooks.md
@@ -178,25 +178,29 @@ import folium
 m = folium.Map(
     location=[45.372, -121.6972],
     zoom_start=12,
-    tiles='Stamen Terrain'
+    tiles='Stamen Terrain',
+    attr="Placeholder attr"
 )
 
 folium.Marker(
     location=[45.3288, -121.6625],
     popup='Mt. Hood Meadows',
-    icon=folium.Icon(icon='cloud')
+    icon=folium.Icon(icon='cloud'),
+    attr="Placeholder attr"
 ).add_to(m)
 
 folium.Marker(
     location=[45.3311, -121.7113],
     popup='Timberline Lodge',
-    icon=folium.Icon(color='green')
+    icon=folium.Icon(color='green'),
+    attr="Placeholder attr"
 ).add_to(m)
 
 folium.Marker(
     location=[45.3300, -121.6823],
     popup='Some Other Location',
-    icon=folium.Icon(color='red', icon='info-sign')
+    icon=folium.Icon(color='red', icon='info-sign'),
+    attr="Placeholder attr"
 ).add_to(m)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py311-sphinx6
+envlist = py310-sphinx6
 
 [testenv]
 usedevelop=true
@@ -30,6 +30,8 @@ commands =
 [testenv:docs-{update,clean}]
 extras =
     doc
+deps =
+    sphinx-theme-builder[cli]
 whitelist_externals = rm
 commands =
     clean: rm -rf docs/_build


### PR DESCRIPTION
Downgrades Windows tests to use Python 3.11 w/ a comment to upgrade once @agoose77 's PR is released.

Updates the tox Python environment to use 3.10 as 3.11 seems buggy.

Fixes documentation notebook errors.