### PR TITLE
FIX: properly handle CSS objects in css_files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,9 @@ jobs:
         python-version: '3.9'
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
+    - name: Install fonts
+      run: sudo apt-get install -y fonts-roboto
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
     - name: Install fonts
+      # This is required until sphinx-opengraph fixes their fallback
       run: sudo apt-get install -y fonts-roboto
 
     - name: Install dependencies
@@ -106,11 +107,12 @@ jobs:
       shell: python
       run: |
         from pathlib import Path
+        import re
         text = Path("./warnings.txt").read_text().strip()
-        expected_warning_snippets = ["kitchen-sink", "urllib/parse.py"]
+        expected_warning_patterns = [r"kitchen\-sink", r"urllib/parse\.py", r"Glyph 10024 .*? missing from current font"]
         print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
-        unexpected = [ii for ii in text.split("\n") if not any(snippet in ii for snippet in expected_warning_snippets)]
-        assert len(unexpected) == 0
+        unexpected = [l for l in text.splitlines() if not any(re.search(p, ii) for p in expected_warning_patterns)]
+        assert len(unexpected) == 0, unexpected
 
     - name: Audit with Lighthouse
       uses: treosh/lighthouse-ci-action@10.1.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx_thebe",
     "sphinx_togglebutton",
-    #    "sphinxcontrib.bibtex",
+    "sphinxcontrib.bibtex",
     "sphinxext.opengraph",
     # For the kitchen sink
     "sphinx.ext.todo",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 import os
 from urllib.request import urlopen
 from pathlib import Path
+import warnings
 
 project = "Sphinx Book Theme"
 copyright = "2023"
@@ -29,11 +30,16 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx_thebe",
     "sphinx_togglebutton",
-    "sphinxcontrib.bibtex",
+    #    "sphinxcontrib.bibtex",
     "sphinxext.opengraph",
     # For the kitchen sink
     "sphinx.ext.todo",
 ]
+
+# Ignore Glyph 10024 (\N{SPARKLES}) missing from current font from "sphinxext.opengraph"
+warnings.filterwarnings(
+    "ignore", "Glyph 10024 .*? missing from current font", UserWarning
+)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,6 @@
 import os
 from urllib.request import urlopen
 from pathlib import Path
-import warnings
 
 project = "Sphinx Book Theme"
 copyright = "2023"
@@ -35,11 +34,6 @@ extensions = [
     # For the kitchen sink
     "sphinx.ext.todo",
 ]
-
-# Ignore Glyph 10024 (\N{SPARKLES}) missing from current font from "sphinxext.opengraph"
-warnings.filterwarnings(
-    "ignore", "Glyph 10024 .*? missing from current font", UserWarning
-)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -77,7 +77,7 @@ def _gen_hash(path: str) -> str:
     return hashlib.sha1(path.read_bytes()).hexdigest()
 
 
-def hash_assets_for_files(assets: list, theme_static: Path, context):
+def hash_assets_for_files(assets: list, theme_static: Path, context, app):
     """Generate a hash for assets, and append to its entry in context.
 
     assets: a list of assets to hash, each path should be relative to
@@ -88,22 +88,36 @@ def hash_assets_for_files(assets: list, theme_static: Path, context):
     context: the Sphinx context object where asset links are stored. These are:
         `css_files` and `script_files` keys.
     """
-    for asset in assets:
+    for asset_path in assets:
         # CSS assets are stored in css_files, JS assets in script_files
-        asset_type = "css_files" if asset.endswith(".css") else "script_files"
+        asset_type = "css_files" if asset_path.endswith(".css") else "script_files"
         if asset_type in context:
             # Define paths to the original asset file, and its linked file in Sphinx
-            asset_sphinx_link = f"_static/{asset}"
-            asset_source_path = theme_static / asset
+            asset_sphinx_link = f"_static/{asset_path}"
+            asset_source_path = theme_static / asset_path
             if not asset_source_path.exists():
                 SPHINX_LOGGER.warning(
                     f"Asset {asset_source_path} does not exist, not linking."
                 )
             # Find this asset in context, and update it to include the digest
-            if asset_sphinx_link in context[asset_type]:
-                hash = _gen_hash(asset_source_path)
-                ix = context[asset_type].index(asset_sphinx_link)
-                context[asset_type][ix] = asset_sphinx_link + "?digest=" + hash
+            for i, other_asset in enumerate(context[asset_type]):
+                # TODO: eventually the contents of context['css_files'] etc should probably
+                #       only be _CascadingStyleSheet etc. For now, assume mixed with strings.
+                if (
+                    getattr(other_asset, "filename", str(other_asset))
+                    != asset_sphinx_link
+                ):
+                    continue
+                # Take priority from existing asset or use default priority (500)
+                priority = getattr(other_asset, "priority", 500)
+                # Remove existing asset
+                del context[asset_type][i]
+                # Add new asset
+                app.add_css_file(
+                    asset_sphinx_link,
+                    digest=_gen_hash(asset_source_path),
+                    priority=priority,
+                )
 
 
 def hash_html_assets(app, pagename, templatename, context, doctree):
@@ -117,7 +131,7 @@ def hash_html_assets(app, pagename, templatename, context, doctree):
     # run but the book theme CSS file won't be linked in Sphinx.
     if app.config.html_theme == "sphinx_book_theme":
         assets.append("styles/sphinx-book-theme.css")
-    hash_assets_for_files(assets, get_html_theme_path() / "static", context)
+    hash_assets_for_files(assets, get_html_theme_path() / "static", context, app)
 
 
 def update_mode_thebe_config(app):


### PR DESCRIPTION
Sphinx 7.26 (approximately) deprecates implicit string operations on the contents of `context['css_files']`. This, in turn, raises warnings for users that enable strict warning checks. This was observed in `jupyter-book`'s test-suite.

This PR updates our handling to first assume objects within this list are `_CascadingStyleSheet` objects, and replaces the object back on the path.