### PR TITLE
DOCS: require compatible docutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ doc = [
     "sphinxcontrib-bibtex",
     "sphinxcontrib-youtube",
     "sphinxext-opengraph",
+    "docutils!=0.17.*,!=0.18.*"
 ]
 test = [
     "beautifulsoup4",


### PR DESCRIPTION
The widespread problem with docutils 0.17 and 0.18 also affects our docs generation. As our optional `docs` extra is intended for internal use only, we can describe the compatibility safely in `pyproject.toml` rather than worrying about backsolving.

Fixes #799 