### PR TITLE
Fix .bd-sizebar-secondary and .secondary-toggle breakpoint

### DIFF
--- a/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
@@ -25,13 +25,8 @@ button.sidebar-toggle.primary-toggle {
 }
 
 // Secondary toggle mimics behavior of "persistent header" div of PST
-<<<<<<< master
-label.sidebar-toggle.secondary-toggle {
-  @media (min-width: $breakpoint-xl) {
-=======
 button.sidebar-toggle.secondary-toggle {
-  @media (min-width: $breakpoint-lg) {
->>>>>>> master
+  @media (min-width: $breakpoint-xl) {
     display: none;
   }
   @media (max-width: $breakpoint-md) {

--- a/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
@@ -26,7 +26,7 @@ label.sidebar-toggle.primary-toggle {
 
 // Secondary toggle mimics behavior of "persistent header" div of PST
 label.sidebar-toggle.secondary-toggle {
-  @media (min-width: $breakpoint-lg) {
+  @media (min-width: $breakpoint-xl) {
     display: none;
   }
   @media (max-width: $breakpoint-md) {

--- a/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -6,7 +6,7 @@
   // So that it sticks to the top of the page instead of the header height
   top: 0;
 
-  @media (max-width: $breakpoint-lg) {
+  @media (max-width: $breakpoint-xl) {
     // So that tooltips don't overlap
     z-index: $zindex-tooltip + 1;
   }
@@ -36,7 +36,7 @@
   }
 
   // Wide screen behavior
-  @media (min-width: $breakpoint-lg) {
+  @media (min-width: $breakpoint-xl) {
     background: var(--pst-color-background);
     height: fit-content;
     transition: max-height 0.4s ease;


### PR DESCRIPTION
My friend find that `.bd-sidebar-secondary` collapse before `.secondary-toggle` appear. Which means, viewport width between 1200px (xl breakpoint) and 992px (lg breakpoint), both sidebar and toggle button disappear.

I find that [a rule come from pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme/blob/f50e7b91c33ada7b7ad0ca9d502559ea9a801ee7/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss#L108-L112) interact with `.bd-sidebar-secondary` cause collapse less that 1200px (exactly at 1199.98px). With the [breakpoint xl](https://github.com/pydata/pydata-sphinx-theme/blob/f50e7b91c33ada7b7ad0ca9d502559ea9a801ee7/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss#L22).

So this PR is for synchronize `.secondary-toogle` button with `.bd-sidebar-secondary` collapse through align breakpoint to xl.