### PR TITLE
fix: use `config-inited` event to register config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ filterwarnings = [
   # jupyter-client throws this
   'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning',
   'ignore:datetime\.datetime\.utcnow\(\) is deprecated:DeprecationWarning',
+  # Sphinx triggers this
+  '''ignore:'imghdr' is deprecated and slated for removal in Python 3\.13:DeprecationWarning''',
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ additional-compiled-static-assets = [
 testpaths = [
     "tests"
 ]
+filterwarnings = [
+  "error",
+  'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
+  'ignore:The frontend\.OptionParser class will be replaced:DeprecationWarning',
+  'ignore:The frontend\.Option class will be removed:DeprecationWarning',
+  'ignore:nodes\.Node\.traverse\(\) is obsoleted by Node\.findall\(\):PendingDeprecationWarning',
+]
 
 [project]
 name = "sphinx-book-theme"
@@ -82,3 +89,5 @@ test = [
 [project.urls]
 Repository = "https://github.com/executablebooks/sphinx-book-theme"
 Documentation = "https://sphinx-book-theme.readthedocs.io/"
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ filterwarnings = [
   'ignore:The frontend\.OptionParser class will be replaced:DeprecationWarning',
   'ignore:The frontend\.Option class will be removed:DeprecationWarning',
   'ignore:nodes\.Node\.traverse\(\) is obsoleted by Node\.findall\(\):PendingDeprecationWarning',
+  # jupyter-client throws this
+  'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning',
+  'ignore:datetime\.datetime\.utcnow\(\) is deprecated:DeprecationWarning',
 ]
 
 [project]

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -4,14 +4,13 @@ import os
 from pathlib import Path
 from functools import lru_cache
 
-from docutils.parsers.rst.directives.body import Sidebar
 from docutils import nodes as docutil_nodes
 from sphinx.application import Sphinx
 from sphinx.locale import get_translation
 from sphinx.util import logging
 from pydata_sphinx_theme.utils import get_theme_options_dict
 
-from .nodes import SideNoteNode
+from .nodes import Margin, SideNoteNode
 from .header_buttons import (
     prep_header_buttons,
     add_header_buttons,
@@ -179,33 +178,12 @@ def check_deprecation_keys(app):
             )
 
 
-class Margin(Sidebar):
-    """Goes in the margin to the right of the page."""
-
-    optional_arguments = 1
-    required_arguments = 0
-
-    def run(self):
-        """Run the directive."""
-        if not self.arguments:
-            self.arguments = [""]
-        nodes = super().run()
-        nodes[0].attributes["classes"].append("margin")
-
-        # Remove the "title" node if it is empty
-        if not self.arguments:
-            nodes[0].children.pop(0)
-        return nodes
-
-
 def update_general_config(app):
     theme_dir = get_html_theme_path()
-    # Update templates for sidebar. Needed for jupyter-book builds as jb
-    # uses an instance of Sphinx class from sphinx.application to build the app.
-    # The __init__ function of which calls self.config.init_values() just
-    # before emitting `config-inited` event. The init_values function overwrites
-    # templates_path variable.
-    app.config.templates_path.append(os.path.join(theme_dir, "components"))
+
+    app.config.templates_path.append(
+        os.path.join(theme_dir, "components")
+    )
 
 
 def update_templates(app, pagename, templatename, context, doctree):
@@ -245,10 +223,19 @@ def setup(app: Sphinx):
     app.connect("builder-inited", check_deprecation_keys)
     app.connect("builder-inited", update_sourcename)
     app.connect("builder-inited", update_context_with_repository_info)
-    app.connect("builder-inited", update_general_config)
     app.connect("html-page-context", add_metadata_to_page)
     app.connect("html-page-context", hash_html_assets)
     app.connect("html-page-context", update_templates)
+
+    # This extension has both theme-like and extension-like features.
+    # Themes are initialised immediately before use, thus we cannot
+    # rely on an event to set the config - the theme config must be 
+    # set in setup(app):
+    update_general_config_config(app)    
+    # Meanwhile, extensions are initialised _first_, and any config
+    # values set during setup() will be overwritten. We must therefore
+    # register the `config-inited` event to set these config options
+    app.connect("config-inited", update_general_config)
 
     # Nodes
     SideNoteNode.add_node(app)
@@ -265,10 +252,6 @@ def setup(app: Sphinx):
 
     # Post-transforms
     app.add_post_transform(HandleFootnoteTransform)
-
-    # Update templates for sidebar, for builds where config-inited is not called
-    # (does not work in case of jupyter-book)
-    app.config.templates_path.append(os.path.join(theme_dir, "components"))
 
     return {
         "parallel_read_safe": True,

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -10,7 +10,8 @@ from sphinx.locale import get_translation
 from sphinx.util import logging
 from pydata_sphinx_theme.utils import get_theme_options_dict
 
-from .nodes import Margin, SideNoteNode
+from .directives import Margin
+from .nodes import SideNoteNode
 from .header_buttons import (
     prep_header_buttons,
     add_header_buttons,

--- a/src/sphinx_book_theme/__init__.py
+++ b/src/sphinx_book_theme/__init__.py
@@ -230,7 +230,7 @@ def setup(app: Sphinx):
     # Themes are initialised immediately before use, thus we cannot
     # rely on an event to set the config - the theme config must be
     # set in setup(app):
-    update_general_config_config(app)
+    update_general_config(app)
     # Meanwhile, extensions are initialised _first_, and any config
     # values set during setup() will be overwritten. We must therefore
     # register the `config-inited` event to set these config options

--- a/src/sphinx_book_theme/directives.py
+++ b/src/sphinx_book_theme/directives.py
@@ -1,0 +1,20 @@
+from docutils.parsers.rst.directives.body import Sidebar
+
+
+class Margin(Sidebar):
+    """Goes in the margin to the right of the page."""
+
+    optional_arguments = 1
+    required_arguments = 0
+
+    def run(self):
+        """Run the directive."""
+        if not self.arguments:
+            self.arguments = [""]
+        nodes = super().run()
+        nodes[0].attributes["classes"].append("margin")
+
+        # Remove the "title" node if it is empty
+        if not self.arguments:
+            nodes[0].children.pop(0)
+        return nodes

--- a/src/sphinx_book_theme/nodes.py
+++ b/src/sphinx_book_theme/nodes.py
@@ -1,7 +1,6 @@
 from docutils import nodes
 from sphinx.application import Sphinx
 from typing import Any, cast
-from docutils.parsers.rst.directives.body import Sidebar
 
 
 class SideNoteNode(nodes.Element):
@@ -37,21 +36,3 @@ def depart_SideNoteNode(self, node):
         f"<input type='checkbox' id='{tagid}' name='{tagid}' class='margin-toggle'>"
     )
 
-
-class Margin(Sidebar):
-    """Goes in the margin to the right of the page."""
-
-    optional_arguments = 1
-    required_arguments = 0
-
-    def run(self):
-        """Run the directive."""
-        if not self.arguments:
-            self.arguments = [""]
-        nodes = super().run()
-        nodes[0].attributes["classes"].append("margin")
-
-        # Remove the "title" node if it is empty
-        if not self.arguments:
-            nodes[0].children.pop(0)
-        return nodes

--- a/src/sphinx_book_theme/nodes.py
+++ b/src/sphinx_book_theme/nodes.py
@@ -1,6 +1,7 @@
 from docutils import nodes
 from sphinx.application import Sphinx
 from typing import Any, cast
+from docutils.parsers.rst.directives.body import Sidebar
 
 
 class SideNoteNode(nodes.Element):
@@ -35,3 +36,22 @@ def depart_SideNoteNode(self, node):
     self.body.append(
         f"<input type='checkbox' id='{tagid}' name='{tagid}' class='margin-toggle'>"
     )
+
+
+class Margin(Sidebar):
+    """Goes in the margin to the right of the page."""
+
+    optional_arguments = 1
+    required_arguments = 0
+
+    def run(self):
+        """Run the directive."""
+        if not self.arguments:
+            self.arguments = [""]
+        nodes = super().run()
+        nodes[0].attributes["classes"].append("margin")
+
+        # Remove the "title" node if it is empty
+        if not self.arguments:
+            nodes[0].children.pop(0)
+        return nodes

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -28,9 +28,10 @@ class SphinxBuild:
             f".sphinx{sphinx.version_info[0]}"  # software version tracking for fixtures
         )
 
-    def build(self, assert_pass=True):
+    def build(self, assert_pass=True, assert_no_warnings=True):
         self.app.build()
-        assert self.warnings == "", self.status
+        if assert_no_warnings:
+            assert self.warnings == "", self.status
         return self
 
     @property
@@ -62,14 +63,10 @@ def sphinx_build_factory(make_app, tmp_path):
     yield _func
 
 
-def test_parallel_build():
-    # We cannot use the sphinx_build_factory because SpinxTestApp does
-    # not have a way to pass parallel=2 to the Sphinx constructor
-    # https://github.com/sphinx-doc/sphinx/blob/d8c006f1c0e612d0dc595ae463b8e4c3ebee5ca4/sphinx/testing/util.py#L101
-    check_call(
-        f"sphinx-build -j 2 -W -b html {path_tests}/sites/parallel-build build",
-        shell=True,
-    )
+def test_parallel_build(sphinx_build_factory):
+    sphinx_build = sphinx_build_factory("parallel-build", parallel=2)  # type: SphinxBuild
+    sphinx_build.build(assert_pass=True, assert_no_warnings=False)  # TODO: filter these warnings
+    assert (sphinx_build.outdir / "index.html").exists(), sphinx_build.outdir.glob("*")
 
 
 def test_build_book(sphinx_build_factory, file_regression):

--- a/tests/test_build/build__pagetoc--page-onetitlenoheadings.html
+++ b/tests/test_build/build__pagetoc--page-onetitlenoheadings.html
@@ -1,0 +1,2 @@
+<div class="bd-sidebar-secondary bd-toc">
+</div>


### PR DESCRIPTION
Fixes #768, obviates need for executablebooks/jupyter-book#2111

I'll restate the rationale here:

The registration order is as follows:
- `[[extensions]] sphinx::Application.setup_extension()`
- `sphinx::Config.init_values()`
- `<config-inited>`
- `sphinx::Builder.init()`
- `[[theme]] sphinx::Registry.load_extension()`
- `sphinx::Builder.create_template_bridge() `
- `<builder-inited>`

Crucially:
1. Extensions are registered _first_.
   - Any theme variables set in `setup()` are subsequently clobbered by `sphinx::Config.init_values`. 
   - `setup()` is called exclusively once for a theme/extension, so these variables are never set again.
   - Extensions must use e.g. `config-inited` to set this value _before_ the theme is required.
1. Themes are registered _later_.
   - Setting theme config directly in `setup()` ensures that the _theme_ search path (in `create_template_bridge` is correct. 
   - We can't use an event for this because the theme is set-up immediately (in `sphinx::Registry.load_extension`) before the path is required (in `sphinx::Builder.create_template_bridge`) i.e. before any further events are dispatched.

What's happening in JB and other users is that they're using SBT as both a theme and an extension, so we start at the top of the registration order. Thus, we need to support both use cases, i.e. set config twice. This is acceptable because due to the registration system we _either_ see 
- config set in `<config-inited>`, but not from `setup()`
- config set in `setup()`, after `<config-inited>` is dispatched

Finally, it should be noted that SBT _needs_ to be in extensions whilst it adds features (the margin directive) that are non-HTML focused.