### PR TITLE
[FIX] fixes to the dropdown buttons

### DIFF
--- a/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
+++ b/src/sphinx_book_theme/assets/styles/sections/_header-article.scss
@@ -91,7 +91,8 @@ label.sidebar-toggle.secondary-toggle {
     font-size: 1.3rem;
     color: var(--pst-color-text-muted);
     border: none;
-    padding: 0 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 
     // Make sure anything inside is aligned vertically
     display: flex;

--- a/src/sphinx_book_theme/header_buttons/launch.py
+++ b/src/sphinx_book_theme/header_buttons/launch.py
@@ -1,4 +1,5 @@
 """Launch buttons for Binder / Thebe / Colab / etc."""
+
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode, quote
@@ -133,7 +134,7 @@ def add_launch_buttons(
             {
                 "type": "link",
                 "text": "Binder",
-                "tooltip": translation("Launch on") + "Binder",
+                "tooltip": translation("Launch on") + " Binder",
                 "icon": "_static/images/logo_binder.svg",
                 "url": url,
             }
@@ -151,7 +152,7 @@ def add_launch_buttons(
             {
                 "type": "link",
                 "text": "JupyterHub",
-                "tooltip": translation("Launch on") + "JupyterHub",
+                "tooltip": translation("Launch on") + " JupyterHub",
                 "icon": "_static/images/logo_jupyterhub.svg",
                 "url": url,
             }
@@ -166,7 +167,7 @@ def add_launch_buttons(
                 {
                     "type": "link",
                     "text": "Colab",
-                    "tooltip": translation("Launch on") + "Colab",
+                    "tooltip": translation("Launch on") + " Colab",
                     "icon": "_static/images/logo_colab.png",
                     "url": url,
                 }
@@ -182,7 +183,7 @@ def add_launch_buttons(
                 {
                     "type": "link",
                     "text": "Deepnote",
-                    "tooltip": translation("Launch on") + "Deepnote",
+                    "tooltip": translation("Launch on") + " Deepnote",
                     "icon": "_static/images/logo_deepnote.svg",
                     "url": url,
                 }

--- a/src/sphinx_book_theme/theme/sphinx_book_theme/macros/buttons.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/macros/buttons.html
@@ -6,7 +6,7 @@
   {% if icon.startswith("fa") -%}
     <i class="{{ icon }}"></i>
   {% else %}
-    <img src="{{ pathto(icon, 1) }}">
+    <img alt="{{ translate(text) }} {{ translate("logo") }}" src="{{ pathto(icon, 1) }}">
   {% endif -%}
 </span>
 {% endif %}

--- a/tests/test_build/build__header-article.html
+++ b/tests/test_build/build__header-article.html
@@ -18,7 +18,7 @@
       </button>
       <ul class="dropdown-menu">
        <li>
-        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onBinder">
+        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
          <span class="btn__icon-container">
           <img src="../_static/images/logo_binder.svg"/>
          </span>
@@ -28,7 +28,7 @@
         </a>
        </li>
        <li>
-        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch onJupyterHub">
+        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch on JupyterHub">
          <span class="btn__icon-container">
           <img src="../_static/images/logo_jupyterhub.svg"/>
          </span>
@@ -38,7 +38,7 @@
         </a>
        </li>
        <li>
-        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onColab">
+        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Colab">
          <span class="btn__icon-container">
           <img src="../_static/images/logo_colab.png"/>
          </span>
@@ -48,7 +48,7 @@
         </a>
        </li>
        <li>
-        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onDeepnote">
+        <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Deepnote">
          <span class="btn__icon-container">
           <img src="../_static/images/logo_deepnote.svg"/>
          </span>

--- a/tests/test_build/build__header-article.html
+++ b/tests/test_build/build__header-article.html
@@ -20,7 +20,7 @@
        <li>
         <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
          <span class="btn__icon-container">
-          <img src="../_static/images/logo_binder.svg"/>
+          <img alt="Binder logo" src="../_static/images/logo_binder.svg"/>
          </span>
          <span class="btn__text-container">
           Binder
@@ -30,7 +30,7 @@
        <li>
         <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch on JupyterHub">
          <span class="btn__icon-container">
-          <img src="../_static/images/logo_jupyterhub.svg"/>
+          <img alt="JupyterHub logo" src="../_static/images/logo_jupyterhub.svg"/>
          </span>
          <span class="btn__text-container">
           JupyterHub
@@ -40,7 +40,7 @@
        <li>
         <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Colab">
          <span class="btn__icon-container">
-          <img src="../_static/images/logo_colab.png"/>
+          <img alt="Colab logo" src="../_static/images/logo_colab.png"/>
          </span>
          <span class="btn__text-container">
           Colab
@@ -50,7 +50,7 @@
        <li>
         <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Deepnote">
          <span class="btn__icon-container">
-          <img src="../_static/images/logo_deepnote.svg"/>
+          <img alt="Deepnote logo" src="../_static/images/logo_deepnote.svg"/>
          </span>
          <span class="btn__text-container">
           Deepnote

--- a/tests/test_build/header__repo-buttons--custom-branch.html
+++ b/tests/test_build/header__repo-buttons--custom-branch.html
@@ -8,7 +8,7 @@
     </button>
     <ul class="dropdown-menu">
      <li>
-      <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/foo?urlpath=tree/section1/ntbk.ipynb" target="_blank" title="Launch onBinder">
+      <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/foo?urlpath=tree/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
        <span class="btn__icon-container">
         <img src="../_static/images/logo_binder.svg"/>
        </span>

--- a/tests/test_build/header__repo-buttons--custom-branch.html
+++ b/tests/test_build/header__repo-buttons--custom-branch.html
@@ -10,7 +10,7 @@
      <li>
       <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/foo?urlpath=tree/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
        <span class="btn__icon-container">
-        <img src="../_static/images/logo_binder.svg"/>
+        <img alt="Binder logo" src="../_static/images/logo_binder.svg"/>
        </span>
        <span class="btn__text-container">
         Binder

--- a/tests/test_build/test_header_launchbtns.html
+++ b/tests/test_build/test_header_launchbtns.html
@@ -7,7 +7,7 @@
   <li>
    <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
     <span class="btn__icon-container">
-     <img src="../_static/images/logo_binder.svg"/>
+     <img alt="Binder logo" src="../_static/images/logo_binder.svg"/>
     </span>
     <span class="btn__text-container">
      Binder
@@ -17,7 +17,7 @@
   <li>
    <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch on JupyterHub">
     <span class="btn__icon-container">
-     <img src="../_static/images/logo_jupyterhub.svg"/>
+     <img alt="JupyterHub logo" src="../_static/images/logo_jupyterhub.svg"/>
     </span>
     <span class="btn__text-container">
      JupyterHub
@@ -27,7 +27,7 @@
   <li>
    <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Colab">
     <span class="btn__icon-container">
-     <img src="../_static/images/logo_colab.png"/>
+     <img alt="Colab logo" src="../_static/images/logo_colab.png"/>
     </span>
     <span class="btn__text-container">
      Colab
@@ -37,7 +37,7 @@
   <li>
    <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Deepnote">
     <span class="btn__icon-container">
-     <img src="../_static/images/logo_deepnote.svg"/>
+     <img alt="Deepnote logo" src="../_static/images/logo_deepnote.svg"/>
     </span>
     <span class="btn__text-container">
      Deepnote

--- a/tests/test_build/test_header_launchbtns.html
+++ b/tests/test_build/test_header_launchbtns.html
@@ -5,7 +5,7 @@
  </button>
  <ul class="dropdown-menu">
   <li>
-   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onBinder">
+   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://mybinder.org/v2/gh/executablebooks/sphinx-book-theme/master?urlpath=lab/tree/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Binder">
     <span class="btn__icon-container">
      <img src="../_static/images/logo_binder.svg"/>
     </span>
@@ -15,7 +15,7 @@
    </a>
   </li>
   <li>
-   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch onJupyterHub">
+   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A//github.com/executablebooks/sphinx-book-theme&amp;urlpath=lab/tree/sphinx-book-theme/TESTPATH/section1/ntbk.ipynb&amp;branch=master" target="_blank" title="Launch on JupyterHub">
     <span class="btn__icon-container">
      <img src="../_static/images/logo_jupyterhub.svg"/>
     </span>
@@ -25,7 +25,7 @@
    </a>
   </li>
   <li>
-   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onColab">
+   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://colab.research.google.com/github/executablebooks/sphinx-book-theme/blob/master/TESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Colab">
     <span class="btn__icon-container">
      <img src="../_static/images/logo_colab.png"/>
     </span>
@@ -35,7 +35,7 @@
    </a>
   </li>
   <li>
-   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch onDeepnote">
+   <a class="btn btn-sm dropdown-item" data-bs-placement="left" data-bs-toggle="tooltip" href="https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fexecutablebooks%2Fsphinx-book-theme%2Fblob%2Fmaster%2FTESTPATH/section1/ntbk.ipynb" target="_blank" title="Launch on Deepnote">
     <span class="btn__icon-container">
      <img src="../_static/images/logo_deepnote.svg"/>
     </span>


### PR DESCRIPTION
This pull request includes a handful of improvements around the drop-down/launch buttons:

- Improves the interactivity of the drop-down buttons: Version 1.0.0 introduced a gap between the hover area and the drop-down. When the mouse would move from the former to the latter (especially if slowly), the drop-down would disappear. You can see this behavior on [the live site](https://sphinx-book-theme.readthedocs.io/en/stable/content/notebooks.html). cc @choldgraf since you did work in this area.
- Adds alt text to the launch button logos
- Adds a space between "Launch on" and the tool name - fixes https://github.com/executablebooks/sphinx-book-theme/issues/722 cc @rhugonnet 

![Screenshot showing "Launch on Colab"](https://github.com/executablebooks/sphinx-book-theme/assets/86842/6e07f1e8-c560-4ca7-894d-e1af12ce9088)