### PR TITLE
MAINT: update pydata-sphinx-theme min version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
   "sphinx>=5",
-  "pydata-sphinx-theme>=0.14",
+  "pydata-sphinx-theme>=0.15.2"
 ]
 
 license = { file = "LICENSE" }
@@ -87,7 +87,6 @@ test = [
     "pytest-cov",
     "pytest-regressions",
     "sphinx_thebe",
-    "pydata-sphinx-theme>=0.15.2"
 ]
 
 [project.entry-points]


### PR DESCRIPTION
Alternatively, we could add duplicate selectors for the old theme approach. This is simpler, and I think it's reasonable to be tied closely to the pydata version (by lower-bound only).