### PR TITLE
Exclude command prompts when using copy button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,9 @@ ogp_social_cards = {
     "image": "_static/logo-square.png",
 }
 
+# -- sphinx-copybutton config -------------------------------------
+copybutton_exclude = ".linenos, .gp"
+
 # -- ABlog config -------------------------------------------------
 blog_path = "reference/blog"
 blog_post_pattern = "reference/blog/*.md"


### PR DESCRIPTION
See:
- https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies
- https://github.com/pydata/pydata-sphinx-theme/pull/2036

Alternatively, don't use prompts in shell commands.