### PR TITLE
Make the generated gettext files reproducible

### DIFF
--- a/src/sphinx_book_theme/_compile_translations.py
+++ b/src/sphinx_book_theme/_compile_translations.py
@@ -25,7 +25,7 @@ def convert_json(folder=None):
     out_folder = folder / ".." / ".." / "theme" / "sphinx_book_theme" / "static"
 
     # compile po
-    for path in (folder / "jsons").glob("*.json"):
+    for path in sorted((folder / "jsons").glob("*.json")):
         data = json.loads(path.read_text("utf8"))
         assert data[0]["symbol"] == "en"
         english = data[0]["text"]


### PR DESCRIPTION
I am packaging sphinx-book-theme for Debian, and one of our goals is to make the built packages reproducible. See https://reproducible-builds.org/ for details.

In this case, the generator of `.po` files depended on file system order, which may vary between different machines and file system types.