### PR TITLE
Make the generated documentation more reproducible

### DIFF
--- a/docs/content/notebooks.md
+++ b/docs/content/notebooks.md
@@ -171,6 +171,7 @@ See [the Pandas Styling docs](https://pandas.pydata.org/pandas-docs/stable/user_
 :tags: [hide-input]
 
 import pandas as pd
+from pandas.io.formats.style import Styler
 
 np.random.seed(24)
 df = pd.DataFrame({'A': np.linspace(1, 10, 10)})
@@ -195,8 +196,8 @@ def highlight_max(s):
     is_max = s == s.max()
     return ['background-color: yellow' if v else '' for v in is_max]
 
-df.style.\
-    applymap(color_negative_red).\
+Styler(df, uuid="1").\
+    map(color_negative_red).\
     apply(highlight_max).\
     set_table_attributes('style="font-size: 10px"')
 ```

--- a/docs/reference/notebooks.md
+++ b/docs/reference/notebooks.md
@@ -29,6 +29,8 @@ It also has a `thebe-init` tag which means it will be executed when you initiali
 # Generate some code that we'll use later on in the page
 import numpy as np
 import matplotlib.pyplot as plt
+
+np.random.seed(0)
 ```
 
 ### Hide inputs
@@ -45,6 +47,7 @@ ax.imshow(square)
 
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ### Hide outputs
@@ -61,6 +64,7 @@ ax.imshow(square)
 
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ### Hide markdown
@@ -93,6 +97,7 @@ ax.imshow(square)
 
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ### Hide the whole cell
@@ -108,6 +113,7 @@ ax.imshow(square)
 
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ## Enriched outputs
@@ -136,6 +142,7 @@ Styled DataFrames (see [the Pandas Styling docs](https://pandas.pydata.org/panda
 :tags: [hide-input]
 
 import pandas as pd
+from pandas.io.formats.style import Styler
 
 np.random.seed(24)
 df = pd.DataFrame({'A': np.linspace(1, 10, 10)})
@@ -160,8 +167,8 @@ def highlight_max(s):
     is_max = s == s.max()
     return ['background-color: yellow' if v else '' for v in is_max]
 
-df.style.\
-    applymap(color_negative_red).\
+Styler(df, uuid="1").\
+    map(color_negative_red).\
     apply(highlight_max).\
     set_table_attributes('style="font-size: 10px"')
 ```

--- a/docs/reference/special-theme-elements.md
+++ b/docs/reference/special-theme-elements.md
@@ -31,6 +31,8 @@ through and see how things look!
 import numpy as np
 import matplotlib.pyplot as plt
 
+np.random.seed(0)
+
 square = np.random.randn(100, 100)
 wide = np.random.randn(100, 1000)
 ```
@@ -41,6 +43,7 @@ wide = np.random.randn(100, 1000)
 ## A full-width square figure
 fig, ax = plt.subplots()
 ax.imshow(square)
+plt.show()
 ```
 
 ```{code-cell} ipython3
@@ -49,12 +52,14 @@ ax.imshow(square)
 ## A full-width wide figure
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ```{code-cell} ipython3
 # Now here's the same figure at regular width
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ### Markdown
@@ -194,6 +199,7 @@ Let's see what happens
 ## code cell in the margin with output
 fig, ax = plt.subplots()
 ax.imshow(wide)
+plt.show()
 ```
 
 ````{margin}


### PR DESCRIPTION
I am packaging sphinx-book-theme for Debian, and one of our goals is to make the built packages reproducible. See https://reproducible-builds.org/ for details.

This pull request makes the following improvements:

- Use static ID for tables generated by pandas. This removes the following diff:
  ```diff
  -<table id="T_08154" style="font-size: 10px">
  +<table id="T_afb07" style="font-size: 10px">
  ```
  We have only one table on the page, so we can just hardcode `1`. Also, replace deprecated `applymap` with `map`.

- Use `plt.show()` as the final statement of matplotlib blocks, to prevent repr of AxesImage being added to HTML, which causes this diff:
  ```diff
  -<matplotlib.image.AxesImage at 0x7fffddde12b0>
  +<matplotlib.image.AxesImage at 0x7f38706eade0>
  ```

- Call `np.random.seed(0)` before using `np.random.randn()`.

After these fixes there are still problems coming from Folium and from equation with automatic label, but I have found no good solution, so I will probably just patch them out in Debian.