### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/reference/kitchen-sink/generic.rst
+++ b/docs/reference/kitchen-sink/generic.rst
@@ -3,7 +3,7 @@
    Licensed under Creative Commons Attribution-ShareAlike 4.0 International License
    SPDX-License-Identifier: CC-BY-SA-4.0
 
-.. |EXAMPLE| image:: https://source.unsplash.com/32x32/daily?icon
+.. |EXAMPLE| image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
     :width: 1em
 
 =============
@@ -110,7 +110,7 @@ Sidebar
 
     Lorem ipsum dolor sit amet consectetur adipisicing elit.
 
-    .. image:: https://source.unsplash.com/200x200/daily?cute+puppy
+    .. image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
 
     Lorem ipsum dolor sit amet consectetur adipisicing elit.
 

--- a/docs/reference/kitchen-sink/generic.rst
+++ b/docs/reference/kitchen-sink/generic.rst
@@ -268,4 +268,4 @@ voluptatem officia culpa optio atque. Quaerat sed quibusdam ratione nam.
 Download Links
 ==============
 
-:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://source.unsplash.com/200x200/daily?cute+puppy>`
+:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg>`

--- a/docs/reference/kitchen-sink/images.rst
+++ b/docs/reference/kitchen-sink/images.rst
@@ -12,18 +12,18 @@ Images
 
 An image:
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
    :height: 200
    :width: 200
 
 A clickable image:
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+puppy
-   :target: https://unsplash.com/
+.. image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
+   :target: https://jupyter.org/
    :height: 200
    :width: 200
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
    :align: right
    :height: 200
    :width: 200
@@ -43,7 +43,7 @@ sapiente veritatis doloribus accusantium molestiae modi recusandae
 excepturi facere, corrupti expedita sit nihil temporibus eius sequi
 animi, illo libero labore fuga.
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. image:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
    :align: left
    :height: 200
    :width: 200
@@ -66,7 +66,7 @@ animi, illo libero labore fuga.
 Figures
 -------
 
-.. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
    :alt: reStructuredText, the markup syntax
 
    A figure is an image with a caption and/or a legend:
@@ -83,7 +83,7 @@ Figures
 
 A figure directive with center alignment
 
-.. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
    :align: center
 
    This caption should be centered.

--- a/docs/reference/kitchen-sink/lists.rst
+++ b/docs/reference/kitchen-sink/lists.rst
@@ -246,11 +246,11 @@ Hlists
 .. hlist::
     :columns: 2
 
-    - .. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+    - .. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
 
          This is a short caption for a figure.
 
-    - .. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+    - .. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
 
          This is a long caption for a figure. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
          Donec porttitor dolor in odio posuere, vitae ornare libero mattis. In lobortis justo vestibulum nibh aliquet, non.

--- a/docs/reference/kitchen-sink/structure.rst
+++ b/docs/reference/kitchen-sink/structure.rst
@@ -83,7 +83,7 @@ luctus efficitur arcu. Cras ut dictum mi. Nulla congue interdum lorem, semper se
 Document Subsection
 -------------------
 
-.. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+.. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
     :align: right
     :figwidth: 200px
 

--- a/docs/reference/kitchen-sink/tables.rst
+++ b/docs/reference/kitchen-sink/tables.rst
@@ -97,11 +97,11 @@ List Tables
 
 .. list-table:: This is a list table with images in it.
 
-    * - .. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+    * - .. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
 
            This is a short caption for a figure.
 
-      - .. figure:: https://source.unsplash.com/200x200/daily?cute+puppy
+      - .. figure:: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
 
            This is a long caption for a figure. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
            Donec porttitor dolor in odio posuere, vitae ornare libero mattis. In lobortis justo vestibulum nibh aliquet, non.

--- a/src/sphinx_book_theme/assets/translations/README.md
+++ b/src/sphinx_book_theme/assets/translations/README.md
@@ -1,7 +1,7 @@
 # Translation workflow
 
 This folder contains code and translations for supporting multiple languages with Sphinx.
-See [the Sphinx internationalization documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-internationalization) for more details.
+See [the Sphinx internationalization documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html) for more details.
 
 ## Structure of translation files
 


### PR DESCRIPTION
This should fix some broken links in our docs.

The main difference is that we stop using unsplash for images because I think that service has been deprecated. I've just switched it to use a static image from jupyter now