### PR TITLE
Conditionally add toggle sidebar button

### DIFF
--- a/src/sphinx_book_theme/theme/sphinx_book_theme/components/toggle-primary-sidebar.html
+++ b/src/sphinx_book_theme/theme/sphinx_book_theme/components/toggle-primary-sidebar.html
@@ -1,3 +1,10 @@
-<button class="sidebar-toggle primary-toggle btn btn-sm" title="Toggle primary sidebar" data-bs-placement="bottom" data-bs-toggle="tooltip">
+{% if sidebars %}
+<button
+  class="sidebar-toggle primary-toggle btn btn-sm"
+  title="Toggle primary sidebar"
+  data-bs-placement="bottom"
+  data-bs-toggle="tooltip"
+>
   <span class="fa-solid fa-bars"></span>
 </button>
+{% endif %}


### PR DESCRIPTION
This fixes the issue where the `sidebar-toggle primary-toggle` button is shown even though there is no sidebar to show. If you for example configure a page to not have a sidebar using the `html_sidebars` setting as [described in the docs](https://sphinx-book-theme.readthedocs.io/en/stable/sections/sidebar-primary.html).

The condition matches how pydata-sphinx-theme does it for rendering the sidebar elements in [sidebar-primary.html](https://github.com/pydata/pydata-sphinx-theme/blob/3a35f55d404b4e4db44faedd9b72b85e37bf5460/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html#L27). 

Cheers!

Solves: #924 