### PR TITLE
MAINT: default branch has been renamed to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: continuous-integration
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - 'v*'
   pull_request:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ theme. See the pages to the left for information about what you can configure wi
 See [the Sphinx Book Theme documentation](https://sphinx-book-theme.readthedocs.io/en/latest/)
 for more information.
 
-[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-book-theme/branch/master/graph/badge.svg
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-book-theme/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/executablebooks/sphinx-book-theme
 
 [rtd-badge]: https://readthedocs.org/projects/sphinx-book-theme/badge/?version=latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ thebe_config = {
 html_theme_options = {
     "path_to_docs": "docs",
     "repository_url": "https://github.com/executablebooks/sphinx-book-theme",
-    "repository_branch": "master",
+    "repository_branch": "main",
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
         "colab_url": "https://colab.research.google.com/",


### PR DESCRIPTION
I've renamed the default branch, this is just to update the configs and docs, too.