### PR TITLE
MAINT: update pydata theme version to 0.17.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,7 @@ html_theme_options = {
     "path_to_docs": "docs",
     "repository_url": "https://github.com/executablebooks/sphinx-book-theme",
     "repository_branch": "main",
+    "search_as_you_type": True,
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
         "colab_url": "https://colab.research.google.com/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "sphinx>=7.0",
-  "pydata-sphinx-theme==0.16.1"
+  "pydata-sphinx-theme==0.17.0"
 ]
 
 license = { file = "LICENSE" }

--- a/tests/test_build/build__pagetoc--page-multipletitles.html
+++ b/tests/test_build/build__pagetoc--page-multipletitles.html
@@ -7,12 +7,12 @@
     Contents
    </div>
    <nav aria-labelledby="pst-page-navigation-heading-2" class="page-toc" id="pst-page-toc-nav">
-    <ul class="visible nav section-nav flex-column">
+    <ul class="pst-show_toc_level nav section-nav flex-column">
      <li class="toc-h1 nav-item toc-entry">
       <a class="reference internal nav-link" href="#">
        4.1. A page with multiple top-level titles
       </a>
-      <ul class="visible nav section-nav flex-column">
+      <ul class="pst-show_toc_level nav section-nav flex-column">
        <li class="toc-h2 nav-item toc-entry">
         <a class="reference internal nav-link" href="#a-sub-heading">
          4.1.1. A sub-heading
@@ -24,7 +24,7 @@
       <a class="reference internal nav-link" href="#another-top-level-title">
        4.2. Another top-level title
       </a>
-      <ul class="visible nav section-nav flex-column">
+      <ul class="pst-show_toc_level nav section-nav flex-column">
        <li class="toc-h2 nav-item toc-entry">
         <a class="reference internal nav-link" href="#another-sub-heading">
          4.2.1. Another sub-heading

--- a/tests/test_build/build__pagetoc--page-onetitle.html
+++ b/tests/test_build/build__pagetoc--page-onetitle.html
@@ -7,7 +7,7 @@
     Contents
    </div>
    <nav aria-labelledby="pst-page-navigation-heading-2" class="page-toc" id="pst-page-toc-nav">
-    <ul class="visible nav section-nav flex-column">
+    <ul class="pst-show_toc_level nav section-nav flex-column">
      <li class="toc-h2 nav-item toc-entry">
       <a class="reference internal nav-link" href="#heres-a-sub-heading">
        4.3.1. Here’s a sub-heading


### PR DESCRIPTION
Updating to `pydata-sphinx-theme==0.17.0` seems to be a minor change for sphinx-book-theme. But it can bring us features developed in pydata-sphinx-theme, especially the `search_as_you_type` feature.

The class change comes from https://github.com/pydata/pydata-sphinx-theme/commit/71ecc96b23d4df7db999fed459fa02bcada4ba21

I have checked with `tox -e docs-live` and no visual impact was observed.

Closes #949