### PR TITLE
Updating pydata-sphinx-theme to 0.20 and sphinx to >=8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
         # Test last 2 major releases of Sphinx; regression fixtures target the latest.
-        sphinx: ["~=8.0", "~=9.0"]
+        sphinx: ["~=8.2", "~=9.0"]
         include:
         - os: windows-latest
           python-version: 3.13
@@ -65,7 +65,7 @@ jobs:
     # Only upload to codecov on pull requests so that we don't trigger rate limit blocks
     # Disabled for now with false &&
     - name: Upload to Codecov
-      if: false && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.sphinx == '~=8.0' && github.repository == 'executablebooks/sphinx-book-theme' && github.event_name == 'pull_request'
+      if: false && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.sphinx == '~=8.2' && github.repository == 'executablebooks/sphinx-book-theme' && github.event_name == 'pull_request'
       uses: codecov/codecov-action@v7.0.0
       with:
         name: ebp-sbt-pytests-py3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ readme = "README.md"
 
 requires-python = ">=3.11"
 dependencies = [
-  "sphinx>=8.0",
-  "pydata-sphinx-theme==0.19.0"
+  "sphinx>=8.2",
+  "pydata-sphinx-theme==0.20.0"
 ]
 
 license = { file = "LICENSE" }

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,6 @@ commands =
 [testenv:py{311,312,313,314}-sphinx{8,9}]
 extras = test
 deps =
-    sphinx8: sphinx>=8,<9
+    sphinx8: sphinx>=8.2,<9
     sphinx9: sphinx>=9,<10
 commands = pytest {posargs}


### PR DESCRIPTION
With this we are catching up with the pydata-sphinx-theme releases.

Also update the minimum sphinx requirement as it's practically set by the upstream theme anyway.