### PR TITLE
Remove `extra_navbar` from the theme options reference

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -49,9 +49,6 @@ These are **in addition to** all of the {external:doc}`options available in the 
 * - `collapse_navbar`
   - bool
   - Whether to collapse the navbar, stopping the tree from being expanded. See [](sidebar:max-navbar-depth), (False is default)
-* - `extra_navbar`
-  - str
-  - Extra HTML to add below the sidebar footer. See [](content-footer:extra-footer).
 * - `extra_footer`
   - str
   - Extra HTML to add in the footer of each page.


### PR DESCRIPTION
Closes #810.

The reporter is right that `docs/reference.md` is the only place `extra_navbar` appears. Confirmed on current `main`:

```
$ grep -rn "extra_navbar" src/ docs/
docs/reference.md:52:* - `extra_navbar`
```

`src/sphinx_book_theme/theme/sphinx_book_theme/theme.conf` declares `extra_footer` but no `extra_navbar`, which is why Sphinx emits `unsupported theme option 'extra_navbar' given` for the config in the report.

The row was stale in a second way as well: it points at `[](content-footer:extra-footer)`, and that target does not exist anywhere in `docs/` either — so the only surviving mention of the option also carried a dangling cross-reference. What the description actually describes ("Extra HTML to add ... footer") is `extra_footer`, the row immediately below it.

### Why remove rather than reinstate

The option described extra HTML below the *sidebar* footer, and that slot does not exist in the current PyData-based layout — the footer is assembled from `footer_content_items` (`author.html, copyright.html, last-updated.html, extra-footer.html`) and the sidebar from `sidebars` in `theme.conf`. Re-adding it would mean designing a new insertion point, which is a feature decision rather than a fix for this issue. Meanwhile a documented option that can only produce a build warning is worse for users than no entry at all — it is what sent the reporter looking.

Happy to open a separate issue for a sidebar-footer slot if you'd want one.

Docs only; no code or template changes.
